### PR TITLE
feat(auth): add username/password credential support and improve netw…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ Thumbs.db
 docs/WECHAT_ARTICLE.md
 docs/项目全面审查报告*
 local-dev/*
+
+# Local development config (port changes, etc.)
+frontend/vite.config.ts
+backend/package-lock.json
+frontend/package-lock.json
+package-lock.json

--- a/backend/src/models/migrations/index.ts
+++ b/backend/src/models/migrations/index.ts
@@ -3,12 +3,16 @@ import v001InitialSchema from './v001_initial_schema';
 import v002AddApiProvider from './v002_add_api_provider';
 import v003AddAIModelsTable from './v003_add_ai_models';
 import v004AddAgentModelFields from './v004_add_agent_model_fields';
+import v005SSHKeyPasswordSupport from './v005_ssh_key_password_support';
+import v006NetworkDeviceCredentials from './v006_network_device_credentials';
 
 export const ALL_MIGRATIONS: Migration[] = [
   v001InitialSchema,
   v002AddApiProvider,
   v003AddAIModelsTable,
   v004AddAgentModelFields,
+  v005SSHKeyPasswordSupport,
+  v006NetworkDeviceCredentials,
 ];
 
 export function createMigrationManager(db: any): MigrationManager {

--- a/backend/src/models/migrations/v005_ssh_key_password_support.ts
+++ b/backend/src/models/migrations/v005_ssh_key_password_support.ts
@@ -1,0 +1,75 @@
+import { Migration } from './migrationFramework';
+import { logger } from '../../utils/logger';
+
+const v005SSHKeyPasswordSupport: Migration = {
+  id: '20240101000005',
+  version: 5,
+  name: 'ssh_key_password_support',
+  description: 'Add username/password support to ssh_keys table for network device authentication',
+
+  up: async (db: any) => {
+    logger.info('🔄 Adding password credential support to ssh_keys table...');
+
+    // SQLite 不支持直接修改列约束，需要重建表
+    db.exec(`
+      CREATE TABLE ssh_keys_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        auth_type TEXT DEFAULT 'key',
+        key_type TEXT,
+        fingerprint TEXT,
+        username TEXT,
+        password TEXT,
+        private_key TEXT,
+        description TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+
+      INSERT INTO ssh_keys_new (id, name, auth_type, key_type, fingerprint, private_key, description, created_at, updated_at)
+      SELECT id, name, 'key', key_type, fingerprint, private_key, description, created_at, updated_at
+      FROM ssh_keys;
+
+      DROP TABLE ssh_keys;
+
+      ALTER TABLE ssh_keys_new RENAME TO ssh_keys;
+
+      CREATE INDEX IF NOT EXISTS idx_ssh_keys_name ON ssh_keys(name);
+      CREATE INDEX IF NOT EXISTS idx_ssh_keys_auth_type ON ssh_keys(auth_type);
+    `);
+
+    logger.info('✅ SSH key password support migration completed');
+  },
+
+  down: async (db: any) => {
+    logger.info('🔄 Rolling back ssh_key_password_support migration...');
+
+    // 回滚：重建表，恢复 private_key NOT NULL
+    db.exec(`
+      CREATE TABLE ssh_keys_backup (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        key_type TEXT NOT NULL,
+        fingerprint TEXT,
+        private_key TEXT NOT NULL,
+        description TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+
+      INSERT INTO ssh_keys_backup (id, name, key_type, fingerprint, private_key, description, created_at, updated_at)
+      SELECT id, name, COALESCE(key_type, 'unknown'), fingerprint, COALESCE(private_key, ''), description, created_at, updated_at
+      FROM ssh_keys;
+
+      DROP TABLE ssh_keys;
+
+      ALTER TABLE ssh_keys_backup RENAME TO ssh_keys;
+
+      CREATE INDEX IF NOT EXISTS idx_ssh_keys_name ON ssh_keys(name);
+    `);
+
+    logger.info('✅ SSH key password support rollback completed');
+  }
+};
+
+export default v005SSHKeyPasswordSupport;

--- a/backend/src/models/migrations/v006_network_device_credentials.ts
+++ b/backend/src/models/migrations/v006_network_device_credentials.ts
@@ -1,0 +1,109 @@
+import { Migration } from './migrationFramework';
+import { logger } from '../../utils/logger';
+
+const v006NetworkDeviceCredentials: Migration = {
+  id: '20240101000006',
+  version: 6,
+  name: 'network_device_credentials',
+  description: 'Add ssh_key_id support to network_devices table for credential management',
+
+  up: async (db: any) => {
+    logger.info('🔄 Adding credential support to network_devices table...');
+
+    // SQLite 不支持直接修改列约束，需要重建表
+    db.exec(`
+      CREATE TABLE network_devices_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        ip_address TEXT NOT NULL UNIQUE,
+        vendor TEXT NOT NULL,
+        model TEXT,
+        os_version TEXT,
+        ssh_port INTEGER DEFAULT 22,
+        ssh_key_id TEXT,
+        username TEXT,
+        password TEXT,
+        enable_password TEXT,
+        location TEXT,
+        role TEXT,
+        status TEXT DEFAULT 'online',
+        last_inspection_at DATETIME,
+        last_inspection_result TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (ssh_key_id) REFERENCES ssh_keys(id) ON DELETE SET NULL
+      );
+
+      INSERT INTO network_devices_new (
+        id, name, ip_address, vendor, model, os_version, ssh_port,
+        username, password, enable_password, location, role, status,
+        last_inspection_at, last_inspection_result, created_at, updated_at
+      )
+      SELECT
+        id, name, ip_address, vendor, model, os_version, ssh_port,
+        username, password, enable_password, location, role, status,
+        last_inspection_at, last_inspection_result, created_at, updated_at
+      FROM network_devices;
+
+      DROP TABLE network_devices;
+
+      ALTER TABLE network_devices_new RENAME TO network_devices;
+
+      CREATE INDEX IF NOT EXISTS idx_network_devices_vendor ON network_devices(vendor);
+      CREATE INDEX IF NOT EXISTS idx_network_devices_status ON network_devices(status);
+      CREATE INDEX IF NOT EXISTS idx_network_devices_ip ON network_devices(ip_address);
+      CREATE INDEX IF NOT EXISTS idx_network_devices_ssh_key ON network_devices(ssh_key_id);
+    `);
+
+    logger.info('✅ Network device credentials migration completed');
+  },
+
+  down: async (db: any) => {
+    logger.info('🔄 Rolling back network_device_credentials migration...');
+
+    db.exec(`
+      CREATE TABLE network_devices_backup (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        ip_address TEXT NOT NULL UNIQUE,
+        vendor TEXT NOT NULL,
+        model TEXT,
+        os_version TEXT,
+        ssh_port INTEGER DEFAULT 22,
+        username TEXT NOT NULL,
+        password TEXT NOT NULL,
+        enable_password TEXT,
+        location TEXT,
+        role TEXT,
+        status TEXT DEFAULT 'online',
+        last_inspection_at DATETIME,
+        last_inspection_result TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+
+      INSERT INTO network_devices_backup (
+        id, name, ip_address, vendor, model, os_version, ssh_port,
+        username, password, enable_password, location, role, status,
+        last_inspection_at, last_inspection_result, created_at, updated_at
+      )
+      SELECT
+        id, name, ip_address, vendor, model, os_version, ssh_port,
+        COALESCE(username, ''), COALESCE(password, ''), enable_password, location, role, status,
+        last_inspection_at, last_inspection_result, created_at, updated_at
+      FROM network_devices;
+
+      DROP TABLE network_devices;
+
+      ALTER TABLE network_devices_backup RENAME TO network_devices;
+
+      CREATE INDEX IF NOT EXISTS idx_network_devices_vendor ON network_devices(vendor);
+      CREATE INDEX IF NOT EXISTS idx_network_devices_status ON network_devices(status);
+      CREATE INDEX IF NOT EXISTS idx_network_devices_ip ON network_devices(ip_address);
+    `);
+
+    logger.info('✅ Network device credentials rollback completed');
+  }
+};
+
+export default v006NetworkDeviceCredentials;

--- a/backend/src/routes/networkDeviceRoutes.ts
+++ b/backend/src/routes/networkDeviceRoutes.ts
@@ -34,12 +34,20 @@ router.get('/:id', (req: Request, res: Response) => {
 // Create device
 router.post('/', (req: Request, res: Response) => {
   try {
-    const { name, ip_address, vendor, model, os_version, ssh_port, username, password, enable_password, location, role } = req.body;
+    const { name, ip_address, vendor, model, os_version, ssh_port, ssh_key_id, username, password, enable_password, location, role } = req.body;
 
-    if (!name || !ip_address || !vendor || !username || !password) {
+    if (!name || !ip_address || !vendor) {
       return res.status(400).json({ 
         success: false, 
-        error: 'Missing required fields: name, ip_address, vendor, username, password' 
+        error: 'Missing required fields: name, ip_address, vendor' 
+      });
+    }
+
+    // 如果没有选择凭证，则必须提供用户名和密码
+    if (!ssh_key_id && (!username || !password)) {
+      return res.status(400).json({ 
+        success: false, 
+        error: '请选择认证凭证或手动输入用户名和密码' 
       });
     }
 
@@ -50,6 +58,7 @@ router.post('/', (req: Request, res: Response) => {
       model,
       os_version,
       ssh_port,
+      ssh_key_id,
       username,
       password,
       enable_password,
@@ -64,7 +73,7 @@ router.post('/', (req: Request, res: Response) => {
     if (message.includes('UNIQUE constraint')) {
       return res.status(409).json({ success: false, error: 'IP address already exists' });
     }
-    res.status(500).json({ success: false, error: 'Failed to create device' });
+    res.status(500).json({ success: false, error: message || 'Failed to create device' });
   }
 });
 

--- a/backend/src/routes/sshKeyRoutes.ts
+++ b/backend/src/routes/sshKeyRoutes.ts
@@ -13,9 +13,12 @@ const sshKeyIdSchema = z.object({ id: z.string().uuid('无效的SSH密钥ID') })
 interface SSHKey {
   id: string;
   name: string;
+  auth_type: 'key' | 'password';
   key_type: string;
   fingerprint: string | null;
-  private_key: string;
+  username: string | null;
+  password: string | null;
+  private_key: string | null;
   description: string | null;
   created_at: string;
   updated_at: string;
@@ -47,13 +50,13 @@ function extractFingerprint(privateKey: string): string {
 router.get('/', (_req: Request, res: Response) => {
   try {
     const keys = db.prepare(`
-      SELECT sk.id, sk.name, sk.key_type, sk.fingerprint, sk.description, sk.created_at, sk.updated_at,
+      SELECT sk.id, sk.name, sk.auth_type, sk.key_type, sk.fingerprint, sk.username, sk.description, sk.created_at, sk.updated_at,
              COUNT(DISTINCT s.id) as usage_count
       FROM ssh_keys sk
       LEFT JOIN servers s ON s.ssh_key_id = sk.id
       GROUP BY sk.id
       ORDER BY sk.created_at DESC
-    `).all() as Array<{ id: string; name: string; key_type: string; fingerprint: string | null; description: string | null; created_at: string; updated_at: string; usage_count: number }>;
+    `).all() as Array<{ id: string; name: string; auth_type: string; key_type: string; fingerprint: string | null; username: string | null; description: string | null; created_at: string; updated_at: string; usage_count: number }>;
     res.json({ success: true, data: keys });
   } catch {
     res.status(500).json({ success: false, error: 'Failed to get SSH keys' });
@@ -62,7 +65,7 @@ router.get('/', (_req: Request, res: Response) => {
 
 router.get('/:id', validateParams(sshKeyIdSchema), (req: Request, res: Response) => {
   try {
-    const key = db.prepare('SELECT id, name, key_type, fingerprint, private_key, description, created_at, updated_at FROM ssh_keys WHERE id = ?').get(req.params.id) as SSHKey | undefined;
+    const key = db.prepare('SELECT id, name, auth_type, key_type, fingerprint, username, password, private_key, description, created_at, updated_at FROM ssh_keys WHERE id = ?').get(req.params.id) as SSHKey | undefined;
     if (!key) {
       return res.status(404).json({ success: false, error: 'SSH key not found' });
     }
@@ -83,30 +86,53 @@ router.get('/:id/usage', validateParams(sshKeyIdSchema), (req: Request, res: Res
 
 router.post('/', requireRole('admin'), validateBody(z.object({
   name: z.string().min(1, '密钥名称不能为空'),
-  private_key: z.string().min(1, '私钥不能为空'),
-  description: z.string().optional(),
+  auth_type: z.enum(['key', 'password'], { message: '认证类型必须是 key 或 password' }),
+  username: z.string().optional().nullable(),
+  password: z.string().optional().nullable(),
+  private_key: z.string().optional().nullable(),
+  description: z.string().optional().nullable(),
+}).refine((data) => {
+  if (data.auth_type === 'key') {
+    return !!data.private_key;
+  }
+  if (data.auth_type === 'password') {
+    return !!data.username && !!data.password;
+  }
+  return false;
+}, {
+  message: 'SSH密钥类型必须提供私钥，用户名密码类型必须提供用户名和密码',
 })), (req: Request, res: Response) => {
   try {
-    const { name, private_key, description } = req.body;
-
-    if (!validatePrivateKey(private_key)) {
-      return res.status(400).json({ success: false, error: '无效的 SSH 私钥格式，请确保粘贴的内容包含完整的私钥文本（从 BEGIN 到 END）' });
-    }
+    const { name, auth_type, username, password, private_key, description } = req.body;
 
     const existing = db.prepare('SELECT id FROM ssh_keys WHERE name = ?').get(name);
     if (existing) {
       return res.status(409).json({ success: false, error: 'SSH key name already exists' });
     }
 
-    const keyType = extractKeyType(private_key);
-    const fingerprint = extractFingerprint(private_key);
-    const encryptedKey = encrypt(private_key);
     const id = randomUUID();
 
-    db.prepare(
-      `INSERT INTO ssh_keys (id, name, key_type, fingerprint, private_key, description)
-       VALUES (?, ?, ?, ?, ?, ?)`
-    ).run(id, name, keyType, fingerprint, encryptedKey, description || null);
+    if (auth_type === 'key') {
+      if (!validatePrivateKey(private_key)) {
+        return res.status(400).json({ success: false, error: '无效的 SSH 私钥格式，请确保粘贴的内容包含完整的私钥文本（从 BEGIN 到 END）' });
+      }
+
+      const keyType = extractKeyType(private_key);
+      const fingerprint = extractFingerprint(private_key);
+      const encryptedKey = encrypt(private_key);
+
+      db.prepare(
+        `INSERT INTO ssh_keys (id, name, auth_type, key_type, fingerprint, private_key, description)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run(id, name, 'key', keyType, fingerprint, encryptedKey, description || null);
+    } else {
+      // password 类型
+      const encryptedPassword = encrypt(password);
+      db.prepare(
+        `INSERT INTO ssh_keys (id, name, auth_type, key_type, username, password, description)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run(id, name, 'password', 'password', username, encryptedPassword, description || null);
+    }
 
     res.json({ success: true, data: { id } });
   } catch {
@@ -116,8 +142,11 @@ router.post('/', requireRole('admin'), validateBody(z.object({
 
 router.put('/:id', requireRole('admin'), validateParams(sshKeyIdSchema), validateBody(z.object({
   name: z.string().min(1).optional(),
-  private_key: z.string().optional(),
-  description: z.string().optional(),
+  auth_type: z.enum(['key', 'password']).optional(),
+  username: z.string().optional().nullable(),
+  password: z.string().optional().nullable(),
+  private_key: z.string().optional().nullable(),
+  description: z.string().optional().nullable(),
 })), (req: Request, res: Response) => {
   try {
     const key = db.prepare('SELECT * FROM ssh_keys WHERE id = ?').get(req.params.id) as SSHKey | undefined;
@@ -125,7 +154,7 @@ router.put('/:id', requireRole('admin'), validateParams(sshKeyIdSchema), validat
       return res.status(404).json({ success: false, error: 'SSH key not found' });
     }
 
-    const { name, private_key, description } = req.body as Record<string, unknown>;
+    const { name, auth_type, username, password, private_key, description } = req.body as Record<string, unknown>;
 
     if (name) {
       const existing = db.prepare('SELECT id FROM ssh_keys WHERE name = ? AND id != ?').get(name, req.params.id);
@@ -137,8 +166,11 @@ router.put('/:id', requireRole('admin'), validateParams(sshKeyIdSchema), validat
     let encryptedKey: string | undefined;
     let newKeyType: string | undefined;
     let newFingerprint: string | undefined;
+    let encryptedPassword: string | undefined;
 
-    if (private_key !== undefined && typeof private_key === 'string' && private_key) {
+    const finalAuthType = (auth_type as string) || key.auth_type;
+
+    if (finalAuthType === 'key' && private_key !== undefined && typeof private_key === 'string' && private_key) {
       if (!validatePrivateKey(private_key)) {
         return res.status(400).json({ success: false, error: '无效的 SSH 私钥格式，请确保粘贴的内容包含完整的私钥文本（从 BEGIN 到 END）' });
       }
@@ -147,19 +179,30 @@ router.put('/:id', requireRole('admin'), validateParams(sshKeyIdSchema), validat
       newFingerprint = extractFingerprint(private_key);
     }
 
+    if (finalAuthType === 'password' && password !== undefined && typeof password === 'string' && password) {
+      encryptedPassword = encrypt(password);
+    }
+
     db.prepare(
       `UPDATE ssh_keys
        SET name = COALESCE(?, name),
+           auth_type = COALESCE(?, auth_type),
            key_type = COALESCE(?, key_type),
            fingerprint = COALESCE(?, fingerprint),
+           username = COALESCE(?, username),
+           password = CASE WHEN ? IS NOT NULL THEN ? ELSE password END,
            private_key = CASE WHEN ? IS NOT NULL THEN ? ELSE private_key END,
            description = COALESCE(?, description),
            updated_at = CURRENT_TIMESTAMP
        WHERE id = ?`
     ).run(
       name,
+      auth_type,
       newKeyType,
       newFingerprint,
+      username,
+      password !== undefined ? encryptedPassword : undefined,
+      password !== undefined ? encryptedPassword : undefined,
       private_key !== undefined ? encryptedKey : undefined,
       private_key !== undefined ? encryptedKey : undefined,
       description,

--- a/backend/src/services/networkDeviceService.ts
+++ b/backend/src/services/networkDeviceService.ts
@@ -13,6 +13,7 @@ export interface NetworkDevice {
   model?: string;
   os_version?: string;
   ssh_port: number;
+  ssh_key_id?: string;
   username: string;
   password: string;
   enable_password?: string;
@@ -32,8 +33,9 @@ export interface CreateDeviceRequest {
   model?: string;
   os_version?: string;
   ssh_port?: number;
-  username: string;
-  password: string;
+  ssh_key_id?: string;
+  username?: string;
+  password?: string;
   enable_password?: string;
   location?: string;
   role?: string;
@@ -44,6 +46,7 @@ export interface UpdateDeviceRequest {
   model?: string;
   os_version?: string;
   ssh_port?: number;
+  ssh_key_id?: string;
   username?: string;
   password?: string;
   enable_password?: string;
@@ -70,13 +73,32 @@ class NetworkDeviceService {
 
   createDevice(data: CreateDeviceRequest): NetworkDevice {
     const id = randomUUID();
-    const encryptedPassword = encrypt(data.password);
+    
+    // 如果选择了凭证，从凭证表获取认证信息
+    let finalUsername = data.username || '';
+    let finalPassword = data.password || '';
+    
+    if (data.ssh_key_id) {
+      const credential = db.prepare(
+        'SELECT auth_type, username, password, private_key FROM ssh_keys WHERE id = ?'
+      ).get(data.ssh_key_id) as { auth_type: string; username: string; password: string; private_key: string } | undefined;
+      
+      if (credential) {
+        if (credential.auth_type === 'password') {
+          finalUsername = credential.username || '';
+          finalPassword = credential.password ? decrypt(credential.password) : '';
+        }
+        // 如果是密钥类型，暂时不支持（网络设备通常使用密码）
+      }
+    }
+    
+    const encryptedPassword = encrypt(finalPassword || data.password || '');
     const encryptedEnablePassword = data.enable_password ? encrypt(data.enable_password) : null;
 
     db.prepare(
       `INSERT INTO network_devices 
-      (id, name, ip_address, vendor, model, os_version, ssh_port, username, password, enable_password, location, role, status)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      (id, name, ip_address, vendor, model, os_version, ssh_port, ssh_key_id, username, password, enable_password, location, role, status)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
       data.name,
@@ -85,7 +107,8 @@ class NetworkDeviceService {
       data.model || null,
       data.os_version || null,
       data.ssh_port || 22,
-      data.username,
+      data.ssh_key_id || null,
+      finalUsername || data.username || '',
       encryptedPassword,
       encryptedEnablePassword,
       data.location || null,
@@ -113,11 +136,24 @@ class NetworkDeviceService {
     if (data.model !== undefined) updates.push({ column: 'model', value: data.model });
     if (data.os_version !== undefined) updates.push({ column: 'os_version', value: data.os_version });
     if (data.ssh_port !== undefined) updates.push({ column: 'ssh_port', value: data.ssh_port });
+    if (data.ssh_key_id !== undefined) updates.push({ column: 'ssh_key_id', value: data.ssh_key_id || null });
     if (data.username !== undefined) updates.push({ column: 'username', value: data.username });
     if (data.password !== undefined) updates.push({ column: 'password', value: encrypt(data.password) });
     if (data.enable_password !== undefined) updates.push({ column: 'enable_password', value: data.enable_password ? encrypt(data.enable_password) : null });
     if (data.location !== undefined) updates.push({ column: 'location', value: data.location });
     if (data.role !== undefined) updates.push({ column: 'role', value: data.role });
+
+    // 如果切换了凭证，更新认证信息
+    if (data.ssh_key_id !== undefined && data.ssh_key_id) {
+      const credential = db.prepare(
+        'SELECT auth_type, username, password FROM ssh_keys WHERE id = ?'
+      ).get(data.ssh_key_id) as { auth_type: string; username: string; password: string } | undefined;
+      
+      if (credential && credential.auth_type === 'password') {
+        updates.push({ column: 'username', value: credential.username || '' });
+        updates.push({ column: 'password', value: encrypt(credential.password ? decrypt(credential.password) : '') });
+      }
+    }
 
     if (updates.length > 0) {
       const setClause = updates.map(u => `${u.column} = ?`).join(', ');

--- a/backend/src/services/sshService.ts
+++ b/backend/src/services/sshService.ts
@@ -223,14 +223,26 @@ class SSHConnectionPool {
       throw new Error(`Failed to decrypt password for server ${serverId}: ${(error as Error).message}`);
     }
 
-    // 优先使用 ssh_key_id 从密钥表获取私钥
+    // 优先使用 ssh_key_id 从密钥表获取认证凭证
     if (server.ssh_key_id) {
-      const sshKey = db.prepare('SELECT private_key FROM ssh_keys WHERE id = ?').get(server.ssh_key_id) as { private_key: string } | undefined;
+      const sshKey = db.prepare('SELECT auth_type, private_key, username, password FROM ssh_keys WHERE id = ?').get(server.ssh_key_id) as { auth_type: string; private_key: string; username: string; password: string } | undefined;
       if (sshKey) {
         try {
-          decryptedPrivateKey = decrypt(sshKey.private_key);
+          if (sshKey.auth_type === 'password') {
+            // 密码类型：使用凭证表中的用户名和密码
+            if (sshKey.password) {
+              decryptedPassword = decrypt(sshKey.password);
+            }
+            if (sshKey.username) {
+              // 更新服务器连接用户名为凭证中的用户名
+              server.username = sshKey.username;
+            }
+          } else {
+            // SSH 密钥类型
+            decryptedPrivateKey = decrypt(sshKey.private_key);
+          }
         } catch (error) {
-          throw new Error(`Failed to decrypt SSH key for server ${serverId}: ${(error as Error).message}`);
+          throw new Error(`Failed to decrypt SSH credential for server ${serverId}: ${(error as Error).message}`);
         }
       }
     }

--- a/frontend/src/components/AddDeviceModal.tsx
+++ b/frontend/src/components/AddDeviceModal.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
-import { X, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
+import { X, CheckCircle2, AlertCircle, Loader2, Key, Lock, User } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import api from '../lib/api';
 import { useToast } from '../contexts/ToastContext';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 
 interface NetworkDevice {
   id?: string;
@@ -11,11 +13,21 @@ interface NetworkDevice {
   model?: string;
   os_version?: string;
   ssh_port?: number;
+  ssh_key_id?: string;
   username: string;
   password?: string;
   enable_password?: string;
   location?: string;
   role?: string;
+}
+
+interface Credential {
+  id: string;
+  name: string;
+  auth_type: 'key' | 'password';
+  key_type: string;
+  username: string | null;
+  description: string | null;
 }
 
 interface AddDeviceModalProps {
@@ -46,6 +58,9 @@ export default function AddDeviceModal({ device, onClose, onSuccess }: AddDevice
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [testingConnection, setTestingConnection] = useState(false);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [useCredential, setUseCredential] = useState(!!device?.ssh_key_id);
+
+  useEscapeKey({ onEscape: onClose, enabled: !isSubmitting });
   
   const [formData, setFormData] = useState({
     name: device?.name || '',
@@ -54,6 +69,7 @@ export default function AddDeviceModal({ device, onClose, onSuccess }: AddDevice
     model: device?.model || '',
     os_version: device?.os_version || '',
     ssh_port: device?.ssh_port || 22,
+    ssh_key_id: device?.ssh_key_id || '',
     username: device?.username || '',
     password: '',
     enable_password: '',
@@ -61,34 +77,94 @@ export default function AddDeviceModal({ device, onClose, onSuccess }: AddDevice
     role: device?.role || 'switch'
   });
 
+  // 获取认证凭证列表
+  const { data: credentials = [] } = useQuery({
+    queryKey: ['ssh-keys'],
+    queryFn: () => api.get('/ssh-keys').then(res => res.data.data)
+  });
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!formData.name || !formData.ip_address || !formData.username || (!isEditing && !formData.password)) {
-      toast.error('请填写必填字段');
+    if (!formData.name || !formData.ip_address) {
+      toast.error('请填写设备名称和 IP 地址');
+      return;
+    }
+
+    // 如果使用凭证，则不需要手动输入用户名密码
+    if (!useCredential && (!formData.username || (!isEditing && !formData.password))) {
+      toast.error('请选择认证凭证或手动输入用户名和密码');
       return;
     }
 
     setIsSubmitting(true);
     try {
+      // 构建提交数据，移除空字符串和未使用的字段
+      const submitData: Record<string, any> = {
+        name: formData.name,
+        ip_address: formData.ip_address,
+        vendor: formData.vendor,
+        ssh_port: formData.ssh_port || 22,
+      };
+      
+      // 可选字段，只在有值时添加
+      if (formData.model) submitData.model = formData.model;
+      if (formData.os_version) submitData.os_version = formData.os_version;
+      if (formData.location) submitData.location = formData.location;
+      if (formData.role) submitData.role = formData.role;
+      if (formData.enable_password) submitData.enable_password = formData.enable_password;
+      
+      // 根据认证方式添加相应字段
+      if (useCredential && formData.ssh_key_id) {
+        submitData.ssh_key_id = formData.ssh_key_id;
+      } else {
+        submitData.username = formData.username;
+        if (!isEditing || formData.password) {
+          submitData.password = formData.password;
+        }
+      }
+      
+      console.log('Submitting device data:', submitData);
+      
       if (isEditing && device?.id) {
-        await api.put(`/network-devices/${device.id}`, formData);
+        await api.put(`/api/network-devices/${device.id}`, submitData);
         toast.success('设备更新成功');
       } else {
-        await api.post('/network-devices', formData);
+        await api.post('/api/network-devices', submitData);
         toast.success('设备添加成功');
       }
       onSuccess();
     } catch (error: any) {
-      toast.error(error.response?.data?.error || '操作失败');
+      console.error('Save device error:', error);
+      console.error('Error response:', error.response?.data);
+      toast.error(error.response?.data?.error || error.response?.data?.message || '操作失败');
     } finally {
       setIsSubmitting(false);
     }
   };
 
   const handleTestConnection = async () => {
-    if (!formData.ip_address || !formData.username || !formData.password) {
-      toast.error('请先填写 IP 地址、用户名和密码');
+    if (!formData.ip_address) {
+      toast.error('请先填写 IP 地址');
+      return;
+    }
+
+    // 如果使用凭证，获取凭证中的认证信息
+    let testUsername = formData.username;
+    let testPassword = formData.password;
+    
+    if (useCredential && formData.ssh_key_id) {
+      const selectedCred = credentials.find((c: Credential) => c.id === formData.ssh_key_id);
+      if (selectedCred && selectedCred.auth_type === 'password') {
+        testUsername = selectedCred.username || '';
+        // 密码需要后端解密，这里简化处理
+        toast.info('使用凭证测试连接需要保存后执行');
+        return;
+      }
+    }
+
+    if (!testUsername || !testPassword) {
+      toast.error('请先填写用户名和密码');
       return;
     }
 
@@ -98,8 +174,8 @@ export default function AddDeviceModal({ device, onClose, onSuccess }: AddDevice
       const response = await api.post('/network-devices/test-connection', {
         ip_address: formData.ip_address,
         ssh_port: formData.ssh_port,
-        username: formData.username,
-        password: formData.password
+        username: testUsername,
+        password: testPassword
       });
       
       setTestResult({
@@ -196,31 +272,89 @@ export default function AddDeviceModal({ device, onClose, onSuccess }: AddDevice
               </select>
             </div>
 
-            <div>
-              <label className="block text-sm font-medium text-text-primary mb-1">用户名 <span className="text-red-500">*</span></label>
-              <input
-                type="text"
-                value={formData.username}
-                onChange={(e) => setFormData({ ...formData, username: e.target.value })}
-                placeholder="admin"
-                className="w-full px-3 py-2 text-sm bg-background border border-border rounded-md text-text-primary placeholder-text-secondary/50 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
-                required
-              />
+            <div className="col-span-2">
+              <label className="block text-sm font-medium text-text-primary mb-2">认证方式</label>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => setUseCredential(true)}
+                  className={`flex items-center gap-2 px-4 py-2 rounded-lg border transition-colors ${
+                    useCredential
+                      ? 'bg-primary/10 border-primary text-primary'
+                      : 'bg-background border-border text-text-secondary hover:border-primary/50'
+                  }`}
+                >
+                  <Key className="w-4 h-4" />
+                  选择凭证
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setUseCredential(false)}
+                  className={`flex items-center gap-2 px-4 py-2 rounded-lg border transition-colors ${
+                    !useCredential
+                      ? 'bg-orange-500/10 border-orange-500 text-orange-500'
+                      : 'bg-background border-border text-text-secondary hover:border-orange-500/50'
+                  }`}
+                >
+                  <User className="w-4 h-4" />
+                  手动输入
+                </button>
+              </div>
             </div>
 
-            <div>
-              <label className="block text-sm font-medium text-text-primary mb-1">
-                密码 {!isEditing && <span className="text-red-500">*</span>}
-              </label>
-              <input
-                type="password"
-                value={formData.password}
-                onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                placeholder={isEditing ? '留空则不修改' : '设备登录密码'}
-                className="w-full px-3 py-2 text-sm bg-background border border-border rounded-md text-text-primary placeholder-text-secondary/50 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
-                required={!isEditing}
-              />
-            </div>
+            {useCredential ? (
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-text-primary mb-1">
+                  认证凭证 <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={formData.ssh_key_id}
+                  onChange={(e) => setFormData({ ...formData, ssh_key_id: e.target.value })}
+                  className="w-full px-3 py-2 text-sm bg-background border border-border rounded-md text-text-primary focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                  required
+                >
+                  <option value="">请选择认证凭证</option>
+                  {credentials
+                    .filter((c: Credential) => c.auth_type === 'password')
+                    .map((cred: Credential) => (
+                      <option key={cred.id} value={cred.id}>
+                        {cred.name} ({cred.username || '无用户名'})
+                      </option>
+                    ))}
+                </select>
+                <p className="mt-1 text-xs text-text-secondary/60">
+                  仅显示账号密码类型的凭证
+                </p>
+              </div>
+            ) : (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-text-primary mb-1">用户名 <span className="text-red-500">*</span></label>
+                  <input
+                    type="text"
+                    value={formData.username}
+                    onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                    placeholder="admin"
+                    className="w-full px-3 py-2 text-sm bg-background border border-border rounded-md text-text-primary placeholder-text-secondary/50 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                    required={!useCredential}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-text-primary mb-1">
+                    密码 {!isEditing && <span className="text-red-500">*</span>}
+                  </label>
+                  <input
+                    type="password"
+                    value={formData.password}
+                    onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                    placeholder={isEditing ? '留空则不修改' : '设备登录密码'}
+                    className="w-full px-3 py-2 text-sm bg-background border border-border rounded-md text-text-primary placeholder-text-secondary/50 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                    required={!isEditing && !useCredential}
+                  />
+                </div>
+              </>
+            )}
 
             <div>
               <label className="block text-sm font-medium text-text-primary mb-1">Enable 密码</label>

--- a/frontend/src/components/InspectionHistory.tsx
+++ b/frontend/src/components/InspectionHistory.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { X, History, Loader2, CheckCircle2, AlertCircle, AlertTriangle } from 'lucide-react';
 import api from '../lib/api';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 
 interface InspectionHistoryProps {
   deviceId: string;
@@ -54,6 +55,8 @@ function formatDuration(ms: number) {
 
 export default function InspectionHistory({ deviceId, deviceName, onClose }: InspectionHistoryProps) {
   const [selectedHistory, setSelectedHistory] = useState<HistoryItem | null>(null);
+
+  useEscapeKey({ onEscape: () => { if (selectedHistory) setSelectedHistory(null); else onClose(); } });
 
   const { data: history = [], isLoading } = useQuery({
     queryKey: ['inspection-history', deviceId],

--- a/frontend/src/components/InspectionResult.tsx
+++ b/frontend/src/components/InspectionResult.tsx
@@ -1,4 +1,5 @@
 import { X, CheckCircle2, AlertCircle, AlertTriangle, Loader2, Clock } from 'lucide-react';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 
 interface InspectionResultProps {
   result: {
@@ -91,6 +92,8 @@ function formatDuration(ms: number) {
 }
 
 export default function InspectionResult({ result, deviceName, onClose }: InspectionResultProps) {
+  useEscapeKey({ onEscape: onClose });
+
   const normalCount = result.results.filter(r => r.status === 'normal').length;
   const warningCount = result.results.filter(r => r.status === 'warning').length;
   const criticalCount = result.results.filter(r => r.status === 'critical').length;

--- a/frontend/src/components/NetworkDeviceCard.tsx
+++ b/frontend/src/components/NetworkDeviceCard.tsx
@@ -46,10 +46,13 @@ const roleIcons: Record<string, { icon: string; label: string }> = {
 export default function NetworkDeviceCard({ device, onEdit, onDelete, onInspect, onTestConnection, onHistory }: NetworkDeviceCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node) &&
+          buttonRef.current && !buttonRef.current.contains(event.target as Node)) {
         setShowMenu(false);
       }
     };
@@ -59,6 +62,14 @@ export default function NetworkDeviceCard({ device, onEdit, onDelete, onInspect,
     }
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showMenu]);
+
+  const handleToggleMenu = () => {
+    if (!showMenu && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setMenuPos({ top: rect.bottom + 4, left: rect.right - 160 });
+    }
+    setShowMenu(!showMenu);
+  };
 
   const vendor = vendorConfig[device.vendor] || { label: device.vendor, color: 'text-text-secondary', bgClass: 'bg-surface border border-border', icon: '⚪' };
   const role = roleIcons[device.role || ''] || { icon: '📦', label: device.role || '设备' };
@@ -92,15 +103,20 @@ export default function NetworkDeviceCard({ device, onEdit, onDelete, onInspect,
               <p className="text-xs text-text-secondary font-mono">{device.ip_address}</p>
             </div>
           </div>
-          <div className="relative" ref={menuRef}>
+          <div className="relative">
             <button
-              onClick={() => setShowMenu(!showMenu)}
+              ref={buttonRef}
+              onClick={handleToggleMenu}
               className="p-1 text-text-secondary hover:text-text-primary hover:bg-surface rounded-md transition-colors"
             >
               <MoreHorizontal className="w-4 h-4" />
             </button>
             {showMenu && (
-              <div className="absolute right-0 top-8 w-40 bg-surface rounded-lg shadow-xl border border-border py-1 z-10">
+              <div
+                ref={menuRef}
+                className="fixed w-40 bg-surface rounded-lg shadow-xl border border-border py-1 z-50"
+                style={{ top: menuPos.top, left: menuPos.left }}
+              >
                 <button
                   onClick={() => { setShowMenu(false); onInspect(device, 'standard'); }}
                   className="w-full flex items-center gap-2 px-3 py-2 text-xs text-text-secondary hover:text-text-primary hover:bg-background transition-colors"

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -63,8 +63,8 @@ const navigationGroups = [
     icon: ServerCog,
     items: [
       { name: '服务器管理', href: '/servers', icon: Server },
-      { name: 'SSH 密钥', href: '/ssh-keys', icon: Key },
       { name: '网络设备', href: '/network-devices', icon: Network },
+      { name: '认证凭证', href: '/ssh-keys', icon: Key },
       { name: 'Web 终端', href: '/terminal', icon: Terminal },
       { name: '远程桌面', href: '/remote-desktop', icon: MonitorPlay },
     ]

--- a/frontend/src/hooks/useEscapeKey.ts
+++ b/frontend/src/hooks/useEscapeKey.ts
@@ -1,0 +1,26 @@
+import { useEffect, useCallback } from 'react';
+
+interface UseEscapeKeyOptions {
+  onEscape: () => void;
+  enabled?: boolean;
+}
+
+/**
+ * Hook to handle ESC key press for closing modals/dialogs
+ */
+export function useEscapeKey({ onEscape, enabled = true }: UseEscapeKeyOptions) {
+  const handleEscape = useCallback((event: KeyboardEvent) => {
+    if (event.key === 'Escape' && enabled) {
+      onEscape();
+    }
+  }, [onEscape, enabled]);
+
+  useEffect(() => {
+    if (enabled) {
+      document.addEventListener('keydown', handleEscape);
+    }
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [handleEscape, enabled]);
+}

--- a/frontend/src/pages/NetworkDevices.tsx
+++ b/frontend/src/pages/NetworkDevices.tsx
@@ -11,6 +11,7 @@ import AddDeviceModal from '../components/AddDeviceModal';
 import NetworkDeviceCard from '../components/NetworkDeviceCard';
 import InspectionResult from '../components/InspectionResult';
 import InspectionHistory from '../components/InspectionHistory';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 
 interface NetworkDevice {
   id: string;
@@ -49,13 +50,20 @@ export default function NetworkDevices() {
   const [showBatchModal, setShowBatchModal] = useState(false);
   const [deleteConfirmDevice, setDeleteConfirmDevice] = useState<NetworkDevice | null>(null);
 
+  // ESC key support for modals
+  useEscapeKey({ onEscape: () => { setShowInspectionModal(false); setInspectingDevice(null); }, enabled: showInspectionModal });
+  useEscapeKey({ onEscape: () => setShowBatchModal(false), enabled: showBatchModal });
+  useEscapeKey({ onEscape: () => { setDeleteConfirmDevice(null); }, enabled: !!deleteConfirmDevice });
+  useEscapeKey({ onEscape: () => { setInspectionResult(null); setInspectingDevice(null); }, enabled: !!inspectionResult });
+  useEscapeKey({ onEscape: () => setShowHistory(null), enabled: !!showHistory });
+
   const { data: devices = [], isLoading } = useQuery({
     queryKey: ['network-devices'],
-    queryFn: () => api.get('/network-devices').then(res => res.data.data)
+    queryFn: () => api.get('/api/network-devices').then(res => res.data.data)
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/network-devices/${id}`),
+    mutationFn: (id: string) => api.delete(`/api/network-devices/${id}`),
     onSuccess: () => {
       toast.success('设备删除成功');
       queryClient.invalidateQueries({ queryKey: ['network-devices'] });
@@ -89,7 +97,7 @@ export default function NetworkDevices() {
   const handleTestConnection = async (device: NetworkDevice) => {
     try {
       toast.info(`正在测试 ${device.name} 的连接...`);
-      const response = await api.post(`/network-devices/${device.id}/test-connection`);
+      const response = await api.post(`/api/network-devices/${device.id}/test-connection`);
       const result = response.data;
       
       if (result.success) {
@@ -111,7 +119,7 @@ export default function NetworkDevices() {
 
     setIsInspecting(true);
     try {
-      const response = await api.post(`/network-devices/${inspectingDevice.id}/inspect`, {
+      const response = await api.post(`/api/network-devices/${inspectingDevice.id}/inspect`, {
         inspectionType,
         customDescription: inspectionType === 'custom' ? customDescription : undefined
       });
@@ -157,7 +165,7 @@ export default function NetworkDevices() {
 
     setIsBatchInspecting(true);
     try {
-      const response = await api.post('/network-devices/batch-inspect', {
+      const response = await api.post('/api/network-devices/batch-inspect', {
         deviceIds: Array.from(selectedDevices),
         inspectionType: 'standard'
       });

--- a/frontend/src/pages/SSHKeys.tsx
+++ b/frontend/src/pages/SSHKeys.tsx
@@ -2,17 +2,20 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Plus, Edit, Trash2, Key, CheckCircle2, X, Copy, Eye, EyeOff,
-  Shield, Fingerprint, Info, Search, Server, AlertTriangle
+  Shield, Fingerprint, Info, Search, Server, AlertTriangle, Lock, User
 } from 'lucide-react';
 import clsx from 'clsx';
 import api from '../lib/api';
 import { useToast } from '../contexts/ToastContext';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 
 interface SSHKey {
   id: string;
   name: string;
+  auth_type: 'key' | 'password';
   key_type: string;
   fingerprint: string | null;
+  username: string | null;
   description: string | null;
   created_at: string;
   updated_at: string;
@@ -32,6 +35,9 @@ export default function SSHKeys() {
   const [selectedKey, setSelectedKey] = useState<SSHKey | null>(null);
   const [formData, setFormData] = useState({
     name: '',
+    auth_type: 'key' as 'key' | 'password',
+    username: '',
+    password: '',
     private_key: '',
     description: '',
   });
@@ -40,6 +46,10 @@ export default function SSHKeys() {
   const [usageServers, setUsageServers] = useState<UsageServer[] | null>(null);
   const [usageLoading, setUsageLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+
+  // ESC key support for modals
+  useEscapeKey({ onEscape: () => { setIsModalOpen(false); resetForm(); setSelectedKey(null); }, enabled: isModalOpen });
+  useEscapeKey({ onEscape: () => setDeleteConfirmKey(null), enabled: !!deleteConfirmKey });
 
   const { data: sshKeys, isLoading } = useQuery({
     queryKey: ['ssh-keys'],
@@ -68,7 +78,7 @@ export default function SSHKeys() {
       queryClient.invalidateQueries({ queryKey: ['ssh-keys'] });
       resetForm();
       setIsModalOpen(false);
-      toast.success('SSH 密钥已添加');
+      toast.success('认证凭证已添加');
     },
     onError: (error: any) => {
       const message = error?.response?.data?.message || error?.message || '添加失败，请重试';
@@ -86,7 +96,7 @@ export default function SSHKeys() {
       resetForm();
       setIsModalOpen(false);
       setSelectedKey(null);
-      toast.success('SSH 密钥已更新');
+      toast.success('认证凭证已更新');
     },
     onError: (error: any) => {
       const message = error?.response?.data?.message || error?.message || '更新失败，请重试';
@@ -101,7 +111,7 @@ export default function SSHKeys() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ssh-keys'] });
       setDeleteConfirmKey(null);
-      toast.success('SSH 密钥已删除');
+      toast.success('认证凭证已删除');
     },
     onError: () => {
       setDeleteConfirmKey(null);
@@ -109,7 +119,7 @@ export default function SSHKeys() {
   });
 
   const resetForm = () => {
-    setFormData({ name: '', private_key: '', description: '' });
+    setFormData({ name: '', auth_type: 'key', username: '', password: '', private_key: '', description: '' });
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -117,20 +127,39 @@ export default function SSHKeys() {
     if (selectedKey) {
       const data: Partial<typeof formData> = {
         name: formData.name,
+        auth_type: formData.auth_type,
         description: formData.description,
       };
-      if (formData.private_key) {
+      if (formData.auth_type === 'key' && formData.private_key) {
         data.private_key = formData.private_key;
+      }
+      if (formData.auth_type === 'password') {
+        if (formData.username) data.username = formData.username;
+        if (formData.password) data.password = formData.password;
       }
       updateMutation.mutate({ id: selectedKey.id, data });
     } else {
-      createMutation.mutate(formData);
+      const data = { ...formData };
+      if (data.auth_type === 'key') {
+        data.username = '';
+        data.password = '';
+      } else {
+        data.private_key = '';
+      }
+      createMutation.mutate(data);
     }
   };
 
   const handleEdit = (key: SSHKey) => {
     setSelectedKey(key);
-    setFormData({ name: key.name, private_key: '', description: key.description || '' });
+    setFormData({
+      name: key.name,
+      auth_type: key.auth_type,
+      username: key.username || '',
+      password: '',
+      private_key: '',
+      description: key.description || ''
+    });
     setIsModalOpen(true);
   };
 
@@ -169,7 +198,8 @@ export default function SSHKeys() {
     );
   }) : [];
 
-  const getKeyTypeText = (type: string) => {
+  const getKeyTypeText = (type: string, authType: string) => {
+    if (authType === 'password') return '账号密码';
     const map: Record<string, string> = {
       openssh: 'OpenSSH',
       rsa: 'RSA',
@@ -181,7 +211,8 @@ export default function SSHKeys() {
     return map[type] || type;
   };
 
-  const getKeyTypeColor = (type: string) => {
+  const getKeyTypeColor = (type: string, authType: string) => {
+    if (authType === 'password') return 'text-orange-500 bg-orange-500/10';
     const map: Record<string, string> = {
       openssh: 'text-emerald-500 bg-emerald-500/10',
       rsa: 'text-blue-500 bg-blue-500/10',
@@ -198,15 +229,15 @@ export default function SSHKeys() {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-text-primary mb-2">SSH 密钥管理</h1>
-            <p className="text-text-secondary">统一管理服务器 SSH 认证私钥，添加服务器时可直接选择使用</p>
+            <h1 className="text-2xl font-bold text-text-primary mb-2">认证凭证管理</h1>
+            <p className="text-text-secondary">统一管理服务器和网络设备的认证凭证（SSH 密钥 / 账号密码）</p>
           </div>
           <button
             onClick={() => { resetForm(); setSelectedKey(null); setIsModalOpen(true); }}
             className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
           >
             <Plus className="w-4 h-4" />
-            添加 SSH 密钥
+            添加认证凭证
           </button>
         </div>
 
@@ -220,15 +251,15 @@ export default function SSHKeys() {
               <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-text-secondary">
                 <div className="flex items-center gap-2">
                   <Shield className="w-3.5 h-3.5 flex-shrink-0 text-status-success" />
-                  <span><strong>AES 加密存储</strong>：所有私钥在数据库中加密存储</span>
+                  <span><strong>AES 加密存储</strong>：所有凭证在数据库中加密存储</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Fingerprint className="w-3.5 h-3.5 flex-shrink-0 text-status-warning" />
-                  <span><strong>指纹标识</strong>：自动生成 SHA256 指纹便于识别</span>
+                  <Key className="w-3.5 h-3.5 flex-shrink-0 text-status-warning" />
+                  <span><strong>双认证方式</strong>：支持 SSH 密钥和账号密码</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Info className="w-3.5 h-3.5 flex-shrink-0 text-status-failed" />
-                  <span><strong>按需解密</strong>：连接服务器时自动解密私钥</span>
+                  <span><strong>按需解密</strong>：连接设备时自动解密凭证</span>
                 </div>
               </div>
             </div>
@@ -241,7 +272,7 @@ export default function SSHKeys() {
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="搜索密钥名称、描述、指纹..."
+            placeholder="搜索凭证名称、描述、指纹..."
             className="w-full pl-10 pr-4 py-2 bg-surface border border-border rounded-lg focus:outline-none focus:border-primary text-text-primary"
           />
         </div>
@@ -262,15 +293,15 @@ export default function SSHKeys() {
           ) : filteredKeys.length === 0 ? (
             <div className="col-span-full flex flex-col items-center justify-center py-16 text-text-secondary">
               <Key className="w-14 h-14 mb-4 opacity-40" />
-              <p className="text-lg mb-1">{searchQuery ? '未找到匹配的 SSH 密钥' : '暂无 SSH 密钥'}</p>
-              <p className="text-sm mb-4">{searchQuery ? '请调整搜索关键词' : '添加您的第一个 SSH 私钥，后续添加服务器时可直接选择使用'}</p>
+              <p className="text-lg mb-1">{searchQuery ? '未找到匹配的认证凭证' : '暂无认证凭证'}</p>
+              <p className="text-sm mb-4">{searchQuery ? '请调整搜索关键词' : '添加您的第一个认证凭证（SSH 密钥或账号密码），后续添加服务器/网络设备时可直接选择使用'}</p>
               {!searchQuery && (
                 <button
                   onClick={() => { resetForm(); setSelectedKey(null); setIsModalOpen(true); }}
                   className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
                 >
                   <Plus className="w-4 h-4" />
-                  添加第一个 SSH 密钥
+                  添加第一个认证凭证
                 </button>
               )}
             </div>
@@ -282,24 +313,29 @@ export default function SSHKeys() {
               >
                 <div className="relative">
                   <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-[#3b82f6]/20 to-[#0ea5e9]/15 border border-[#3b82f6]/25">
-                      <Key className="h-4 w-4 text-[#60a5fa]" />
+                    <div className={clsx("flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border",
+                      key.auth_type === 'password'
+                        ? 'bg-gradient-to-br from-[#f97316]/20 to-[#ea580c]/15 border-[#f97316]/25'
+                        : 'bg-gradient-to-br from-[#3b82f6]/20 to-[#0ea5e9]/15 border-[#3b82f6]/25'
+                    )}>
+                      {key.auth_type === 'password' ? (
+                        <Lock className="h-4 w-4 text-[#fb923c]" />
+                      ) : (
+                        <Key className="h-4 w-4 text-[#60a5fa]" />
+                      )}
                     </div>
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <h3 className="truncate text-sm font-semibold text-white/95">{key.name}</h3>
                         <span className={clsx('inline-flex shrink-0 items-center px-1.5 py-0.5 text-[10px] font-semibold rounded',
-                          key.key_type === 'rsa' ? 'bg-[#3b82f6]/15 text-[#60a5fa] border border-[#3b82f6]/25' :
-                          key.key_type === 'ed25519' ? 'bg-[#22c55e]/15 text-[#4ade80] border border-[#22c55e]/25' :
-                          key.key_type === 'ecdsa' ? 'bg-[#f59e0b]/15 text-[#fbbf24] border border-[#f59e0b]/25' :
-                          'bg-[#a855f7]/15 text-[#c084fc] border border-[#a855f7]/25'
+                          getKeyTypeColor(key.key_type, key.auth_type)
                         )}>
-                          {getKeyTypeText(key.key_type)}
+                          {getKeyTypeText(key.key_type, key.auth_type)}
                         </span>
                       </div>
                       <div className="mt-0.5 flex items-center gap-1 text-[11px] text-[#94a3b8]">
                         <Server className="h-3 w-3" />
-                        <span>{key.usage_count} 台服务器</span>
+                        <span>{key.usage_count} 台设备</span>
                         <span className="mx-1 text-[#4a5568]">·</span>
                         <span>{new Date(key.created_at).toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' })}</span>
                       </div>
@@ -377,7 +413,7 @@ export default function SSHKeys() {
                   {usageServers !== null && (
                     <div className="mt-4 p-4 bg-background/50 border border-border rounded-lg">
                       <div className="flex items-center justify-between mb-2">
-                        <span className="text-xs font-medium text-text-primary">使用该密钥的服务器（{usageServers.length} 台）</span>
+                        <span className="text-xs font-medium text-text-primary">使用该凭证的服务器（{usageServers.length} 台）</span>
                         <button onClick={() => setUsageServers(null)} className="p-0.5 hover:bg-surface rounded transition-colors">
                           <X className="w-3.5 h-3.5 text-text-tertiary" />
                         </button>
@@ -410,44 +446,112 @@ export default function SSHKeys() {
         <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
           <div className="bg-surface rounded-xl p-6 w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto">
             <h3 className="text-xl font-bold text-text-primary mb-6">
-              {selectedKey ? '编辑 SSH 密钥' : '添加 SSH 密钥'}
+              {selectedKey ? '编辑认证凭证' : '添加认证凭证'}
             </h3>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-text-secondary mb-2">密钥名称</label>
+                <label className="block text-sm font-medium text-text-secondary mb-2">凭证名称</label>
                 <input
                   type="text"
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  placeholder="例如: production-key, deploy-key"
+                  placeholder="例如: production-key, switch-admin"
                   className="w-full px-4 py-2 bg-background border border-border rounded-lg focus:outline-none focus:border-primary text-text-primary"
                   required
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-text-secondary mb-2">
-                  私钥 {selectedKey && '（留空则不修改）'}
-                </label>
-                <textarea
-                  value={formData.private_key}
-                  onChange={(e) => setFormData({ ...formData, private_key: e.target.value })}
-                  placeholder={selectedKey ? '留空以保持当前私钥不变' : '粘贴您的 SSH 私钥内容...'}
-                  rows={8}
-                  className="w-full px-4 py-2 bg-black/60 border border-border rounded-lg focus:outline-none focus:border-primary font-mono text-sm text-green-400 resize-none"
-                  required={!selectedKey}
-                />
-                <p className="mt-1 text-xs text-text-tertiary">
-                  支持 OpenSSH、RSA、EC、DSA 等格式的私钥
-                </p>
+                <label className="block text-sm font-medium text-text-secondary mb-2">认证类型</label>
+                <div className="flex gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setFormData({ ...formData, auth_type: 'key' })}
+                    className={clsx(
+                      'flex items-center gap-2 px-4 py-2 rounded-lg border transition-colors',
+                      formData.auth_type === 'key'
+                        ? 'bg-primary/10 border-primary text-primary'
+                        : 'bg-background border-border text-text-secondary hover:border-primary/50'
+                    )}
+                  >
+                    <Key className="w-4 h-4" />
+                    SSH 密钥
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setFormData({ ...formData, auth_type: 'password' })}
+                    className={clsx(
+                      'flex items-center gap-2 px-4 py-2 rounded-lg border transition-colors',
+                      formData.auth_type === 'password'
+                        ? 'bg-orange-500/10 border-orange-500 text-orange-500'
+                        : 'bg-background border-border text-text-secondary hover:border-orange-500/50'
+                    )}
+                  >
+                    <Lock className="w-4 h-4" />
+                    账号密码
+                  </button>
+                </div>
               </div>
+
+              {formData.auth_type === 'key' ? (
+                <div>
+                  <label className="block text-sm font-medium text-text-secondary mb-2">
+                    私钥 {selectedKey && '（留空则不修改）'}
+                  </label>
+                  <textarea
+                    value={formData.private_key}
+                    onChange={(e) => setFormData({ ...formData, private_key: e.target.value })}
+                    placeholder={selectedKey ? '留空以保持当前私钥不变' : '粘贴您的 SSH 私钥内容...'}
+                    rows={8}
+                    className="w-full px-4 py-2 bg-black/60 border border-border rounded-lg focus:outline-none focus:border-primary font-mono text-sm text-green-400 resize-none"
+                    required={!selectedKey}
+                  />
+                  <p className="mt-1 text-xs text-text-tertiary">
+                    支持 OpenSSH、RSA、EC、DSA 等格式的私钥
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <div>
+                    <label className="block text-sm font-medium text-text-secondary mb-2">
+                      <User className="w-3.5 h-3.5 inline mr-1" />
+                      用户名
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.username}
+                      onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                      placeholder="例如: admin, root"
+                      className="w-full px-4 py-2 bg-background border border-border rounded-lg focus:outline-none focus:border-primary text-text-primary"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-text-secondary mb-2">
+                      <Lock className="w-3.5 h-3.5 inline mr-1" />
+                      密码
+                    </label>
+                    <input
+                      type="password"
+                      value={formData.password}
+                      onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                      placeholder={selectedKey ? '留空以保持当前密码不变' : '输入密码...'}
+                      className="w-full px-4 py-2 bg-background border border-border rounded-lg focus:outline-none focus:border-primary text-text-primary"
+                      required={!selectedKey}
+                    />
+                    <p className="mt-1 text-xs text-text-tertiary">
+                      密码将使用 AES-256-GCM 加密存储
+                    </p>
+                  </div>
+                </>
+              )}
 
               <div>
                 <label className="block text-sm font-medium text-text-secondary mb-2">描述</label>
                 <textarea
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  placeholder="密钥用途说明..."
+                  placeholder="凭证用途说明..."
                   rows={2}
                   className="w-full px-4 py-2 bg-background border border-border rounded-lg focus:outline-none focus:border-primary text-text-primary"
                 />
@@ -466,7 +570,7 @@ export default function SSHKeys() {
                   className="flex-1 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
                 >
                   <CheckCircle2 className="w-4 h-4" />
-                  {selectedKey ? '保存更改' : '添加密钥'}
+                  {selectedKey ? '保存更改' : '添加凭证'}
                 </button>
               </div>
             </form>

--- a/frontend/src/pages/Servers.tsx
+++ b/frontend/src/pages/Servers.tsx
@@ -13,6 +13,7 @@ import clsx from 'clsx';
 import api from '../lib/api';
 import { useToast } from '../contexts/ToastContext';
 import { ImportExport } from '../components/ImportExport';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 
 interface Server {
   id: string;
@@ -125,6 +126,13 @@ export default function Servers() {
   const [showAiCommandConfirm, setShowAiCommandConfirm] = useState(false);
   const [aiGenerationError, setAiGenerationError] = useState('');
 
+  // ESC key support for modals
+  useEscapeKey({ onEscape: () => { setIsModalOpen(false); setSelectedServer(null); resetForm(); }, enabled: isModalOpen });
+  useEscapeKey({ onEscape: () => setIsImportModalOpen(false), enabled: isImportModalOpen });
+  useEscapeKey({ onEscape: () => { setIsGroupModalOpen(false); setEditingGroup(null); }, enabled: isGroupModalOpen });
+  useEscapeKey({ onEscape: () => { setIsAiCommandModalOpen(false); setAiPrompt(''); setAiGeneratedCommand(''); setAiCommandExplanation(''); setAiGenerationError(''); setShowAiCommandConfirm(false); }, enabled: isAiCommandModalOpen });
+  useEscapeKey({ onEscape: () => { setIsDeleteConfirmOpen(false); setPendingDeleteServer(null); }, enabled: isDeleteConfirmOpen });
+
   // 获取 Agent 列表（用于 AI 生成命令）
   const { data: agents } = useQuery({
     queryKey: ['agents'],
@@ -134,7 +142,7 @@ export default function Servers() {
     },
     enabled: true
   });
-  // SSH 密钥列表（用于选择已有密钥）
+  // 认证凭证列表（用于选择已有凭证）
   const { data: sshKeys } = useQuery({
     queryKey: ['ssh-keys'],
     queryFn: async () => {
@@ -222,7 +230,7 @@ export default function Servers() {
       .flatMap((server: Server) => Array.isArray(server.tags) ? server.tags : [])
   )).sort();
 
-  // 过滤 SSH 密钥列表（按名称、类型或指纹搜索）
+  // 过滤认证凭证列表（按名称、类型或指纹搜索）
   const filteredSshKeys = useMemo(() => {
     if (!sshKeys) return [];
     if (!sshKeySearchQuery) return sshKeys;
@@ -479,7 +487,7 @@ export default function Servers() {
     const serverSshKeyId = (server as any).ssh_key_id || '';
     setSelectedSshKeyId(serverSshKeyId);
     
-    // 如果有 SSH 密钥 ID，设置搜索框显示名称
+    // 如果有认证凭证 ID，设置搜索框显示名称
     if (serverSshKeyId && sshKeys) {
       const key = sshKeys.find(k => k.id === serverSshKeyId);
       if (key) {
@@ -1735,7 +1743,7 @@ ${serverInfo.disk_gb ? `磁盘大小：${serverInfo.disk_gb}GB` : ''}
                     onChange={(e) => setFormData({ ...formData, use_ssh_key: e.target.checked })}
                     className="rounded border-border"
                   />
-                  <label htmlFor="use_ssh_key" className="text-sm text-text-secondary">使用 SSH 密钥</label>
+                  <label htmlFor="use_ssh_key" className="text-sm text-text-secondary">使用认证凭证</label>
                 </div>
 
                 {!formData.use_ssh_key ? (
@@ -1848,7 +1856,7 @@ ${serverInfo.disk_gb ? `磁盘大小：${serverInfo.disk_gb}GB` : ''}
                             onClick={() => { resetForm(); setIsModalOpen(false); navigate('/ssh-keys'); }}
                             className="text-xs text-primary hover:underline"
                           >
-                            + 管理 SSH 密钥
+                            + 管理认证凭证
                           </button>
                         </div>
                       </div>


### PR DESCRIPTION
…ork device management

- Add password authentication to SSH key management (renamed to "认证凭证")
- Support selecting credentials when adding network devices
- Add database migrations for credential password fields and device credential linkage
- Fix API endpoint paths and device list display issues
- Fix dropdown menu overflow in device cards (delete button now visible)
- Add ESC key support to close all modals across the application
- Update sidebar menu order: 网络设备 before 认证凭证
- Add local dev config files to .gitignore

Refs: credential-management, network-device-module

## 变更类型

<!-- 请勾选以下适用的类型 -->

- [ ] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 代码重构 (refactor)
- [ ] 样式/格式调整 (style)
- [ ] 测试相关 (test)
- [ ] 构建/部署/脚本 (chore)

## 变更描述

- 认证凭证管理（原 SSH 密钥）增加用户名/密码支持
- 网络设备添加时可选择已有认证凭证
- 数据库迁移文件（密码字段 + 设备凭证关联）
- API 路径修复、设备列表展示修复
- 网络设备下拉菜单溢出修复（删除按钮可见）
- 全站弹窗 ESC 键关闭支持
- 侧边栏菜单顺序调整
- .gitignore 忽略本地开发配置

## 相关问题

<!-- 关联的 Issue 编号，例如 Fixes #123 -->

## 测试方法

<!-- 请描述如何测试这些变更 -->

- [ ] 已在本地环境测试通过
- [ ] 已运行 `npm run lint` 检查代码风格
- [ ] 已运行后端测试 `cd backend && npm test`
- [ ] 已更新相关文档（如适用）

## 截图（前端变更适用）

<!-- 如果涉及前端 UI 变更，请附上截图 -->

## 补充说明

<!-- 其他需要说明的内容 -->
