### PR TITLE
fix(web terminal): fix terminal credential handling

### DIFF
--- a/backend/src/models/migrations/v005_ssh_key_password_support.ts
+++ b/backend/src/models/migrations/v005_ssh_key_password_support.ts
@@ -21,13 +21,14 @@ const v005SSHKeyPasswordSupport: Migration = {
         username TEXT,
         password TEXT,
         private_key TEXT,
+        passphrase TEXT,
         description TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
       );
 
-      INSERT INTO ssh_keys_new (id, name, auth_type, key_type, fingerprint, private_key, description, created_at, updated_at)
-      SELECT id, name, 'key', key_type, fingerprint, private_key, description, created_at, updated_at
+      INSERT INTO ssh_keys_new (id, name, auth_type, key_type, fingerprint, private_key, passphrase, description, created_at, updated_at)
+      SELECT id, name, 'key', key_type, fingerprint, private_key, passphrase, description, created_at, updated_at
       FROM ssh_keys;
 
       DROP TABLE ssh_keys;
@@ -52,13 +53,14 @@ const v005SSHKeyPasswordSupport: Migration = {
         key_type TEXT NOT NULL,
         fingerprint TEXT,
         private_key TEXT NOT NULL,
+        passphrase TEXT,
         description TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
       );
 
-      INSERT INTO ssh_keys_backup (id, name, key_type, fingerprint, private_key, description, created_at, updated_at)
-      SELECT id, name, COALESCE(key_type, 'unknown'), fingerprint, COALESCE(private_key, ''), description, created_at, updated_at
+      INSERT INTO ssh_keys_backup (id, name, key_type, fingerprint, private_key, passphrase, description, created_at, updated_at)
+      SELECT id, name, COALESCE(key_type, 'unknown'), fingerprint, COALESCE(private_key, ''), passphrase, description, created_at, updated_at
       FROM ssh_keys;
 
       DROP TABLE ssh_keys;

--- a/backend/src/services/networkResultParser.ts
+++ b/backend/src/services/networkResultParser.ts
@@ -330,6 +330,14 @@ export function getParser(vendor: VendorType, type: InspectionType): (output: st
       version: parseVersion,
       routes: parseRoutes,
       log: parseLogBuffer
+    },
+    hikvision: {
+      cpu: parseH3cCpu,
+      memory: parseH3cMemory,
+      interface: parseInterfaceBrief,
+      version: parseVersion,
+      routes: parseRoutes,
+      log: parseLogBuffer
     }
   };
 

--- a/backend/src/services/terminalService.ts
+++ b/backend/src/services/terminalService.ts
@@ -57,6 +57,7 @@ interface ServerInfo {
   username: string;
   password: string | null;
   private_key: string | null;
+  ssh_key_id: string | null;
   use_ssh_key: number;
   enabled?: number;
 }
@@ -81,8 +82,35 @@ export class TerminalService {
       return { sessionId: '', shell: null as unknown as ClientChannel, error: 'Server is disabled' };
     }
 
-    const decryptedPassword = server.password ? decrypt(server.password) : undefined;
-    const decryptedPrivateKey = server.private_key ? decrypt(server.private_key) : undefined;
+    let decryptedPassword = server.password ? decrypt(server.password) : undefined;
+    let decryptedPrivateKey = server.private_key ? decrypt(server.private_key) : undefined;
+    let decryptedPassphrase: string | undefined;
+
+    // 优先使用 ssh_key_id 从认证凭证表获取认证信息
+    if (server.ssh_key_id) {
+      const sshKey = db.prepare('SELECT auth_type, private_key, passphrase, username, password FROM ssh_keys WHERE id = ?').get(server.ssh_key_id) as { auth_type: string; private_key: string; passphrase?: string; username?: string; password?: string } | undefined;
+      if (sshKey) {
+        try {
+          if (sshKey.auth_type === 'password') {
+            // 密码类型：使用凭证表中的用户名和密码
+            if (sshKey.password) {
+              decryptedPassword = decrypt(sshKey.password);
+            }
+            if (sshKey.username) {
+              server.username = sshKey.username;
+            }
+          } else {
+            // SSH 密钥类型
+            decryptedPrivateKey = decrypt(sshKey.private_key);
+            if (sshKey.passphrase) {
+              decryptedPassphrase = decrypt(sshKey.passphrase);
+            }
+          }
+        } catch (error) {
+          return { sessionId: '', shell: null as unknown as ClientChannel, error: `Failed to decrypt SSH credential: ${(error as Error).message}` };
+        }
+      }
+    }
 
     return new Promise((resolve) => {
       const conn = new Client();
@@ -175,6 +203,9 @@ export class TerminalService {
 
       if (server.use_ssh_key && decryptedPrivateKey) {
         connectConfig.privateKey = decryptedPrivateKey;
+        if (decryptedPassphrase) {
+          connectConfig.passphrase = decryptedPassphrase;
+        }
       } else if (decryptedPassword) {
         connectConfig.password = decryptedPassword;
       } else {

--- a/backend/src/services/vendorAdapter.ts
+++ b/backend/src/services/vendorAdapter.ts
@@ -1,6 +1,6 @@
 import { logger } from '../utils/logger';
 
-export type VendorType = 'huawei' | 'cisco' | 'h3c' | 'ruijie' | 'zte';
+export type VendorType = 'huawei' | 'cisco' | 'h3c' | 'ruijie' | 'zte' | 'hikvision';
 
 export type InspectionType = 
   | 'cpu' 
@@ -556,13 +556,119 @@ class ZteAdapter implements VendorAdapter {
   }
 }
 
+class HikvisionAdapter implements VendorAdapter {
+  vendor: VendorType = 'hikvision';
+
+  private templates: Record<InspectionType, CommandTemplate> = {
+    cpu: {
+      type: 'cpu',
+      name: 'CPU 使用率',
+      command: 'display cpu-usage',
+      description: '检查设备 CPU 使用率，正常应低于 80%',
+      expectedPattern: 'CPU utilization',
+      thresholds: { warning: 70, critical: 85 }
+    },
+    memory: {
+      type: 'memory',
+      name: '内存使用率',
+      command: 'display memory',
+      description: '检查设备内存使用情况，正常应低于 85%',
+      expectedPattern: 'Memory',
+      thresholds: { warning: 75, critical: 90 }
+    },
+    interface: {
+      type: 'interface',
+      name: '接口状态',
+      command: 'display interface brief',
+      description: '检查所有接口物理状态和协议状态',
+      expectedPattern: 'Link|Protocol'
+    },
+    version: {
+      type: 'version',
+      name: '系统版本',
+      command: 'display version',
+      description: '检查设备型号、软件版本和运行时间'
+    },
+    routes: {
+      type: 'routes',
+      name: '路由表',
+      command: 'display ip routing-table',
+      description: '检查路由表状态和路由数量'
+    },
+    log: {
+      type: 'log',
+      name: '日志缓冲区',
+      command: 'display logbuffer',
+      description: '检查最近的系统日志和告警信息'
+    },
+    environment: {
+      type: 'environment',
+      name: '环境状态',
+      command: 'display environment',
+      description: '检查设备温度和电压状态'
+    },
+    power: {
+      type: 'power',
+      name: '电源状态',
+      command: 'display power',
+      description: '检查电源模块状态'
+    },
+    fan: {
+      type: 'fan',
+      name: '风扇状态',
+      command: 'display fan',
+      description: '检查风扇模块运行状态'
+    },
+    stp: {
+      type: 'stp',
+      name: 'STP 状态',
+      command: 'display stp brief',
+      description: '检查生成树协议状态和端口角色'
+    },
+    vlan: {
+      type: 'vlan',
+      name: 'VLAN 信息',
+      command: 'display vlan all',
+      description: '检查 VLAN 配置和端口成员'
+    },
+    arp: {
+      type: 'arp',
+      name: 'ARP 表',
+      command: 'display arp',
+      description: '检查 ARP 表项数量和状态'
+    },
+    mac: {
+      type: 'mac',
+      name: 'MAC 地址表',
+      command: 'display mac-address',
+      description: '检查 MAC 地址表项'
+    }
+  };
+
+  getCommands(types?: InspectionType[]): CommandTemplate[] {
+    if (!types) {
+      return Object.values(this.templates);
+    }
+    return types.map(type => this.templates[type]).filter(Boolean);
+  }
+
+  getCommand(type: InspectionType): CommandTemplate | undefined {
+    return this.templates[type];
+  }
+
+  supportsEnablePassword(): boolean {
+    return true;
+  }
+}
+
 export function createVendorAdapter(vendor: VendorType): VendorAdapter {
   const adapters: Record<VendorType, VendorAdapter> = {
     huawei: new HuaweiAdapter(),
     cisco: new CiscoAdapter(),
     h3c: new H3cAdapter(),
     ruijie: new RuijieAdapter(),
-    zte: new ZteAdapter()
+    zte: new ZteAdapter(),
+    hikvision: new HikvisionAdapter()
   };
 
   const adapter = adapters[vendor];

--- a/backend/src/utils/logger.test.ts
+++ b/backend/src/utils/logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -6,12 +6,15 @@ import { logger, LogLevel, LogEntry } from './logger';
 
 describe('Logger', () => {
   let logStats: any;
+  let consoleSpy: any;
 
   beforeEach(() => {
     logStats = logger.getStats();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    consoleSpy?.mockRestore();
   });
 
   describe('log levels', () => {

--- a/frontend/src/components/AddDeviceModal.tsx
+++ b/frontend/src/components/AddDeviceModal.tsx
@@ -40,6 +40,7 @@ const vendors = [
   { value: 'huawei', label: '华为 (Huawei)' },
   { value: 'cisco', label: '思科 (Cisco)' },
   { value: 'h3c', label: '华三 (H3C)' },
+  { value: 'hikvision', label: '海康 (Hikvision)' },
   { value: 'ruijie', label: '锐捷 (Ruijie)' },
   { value: 'zte', label: '中兴 (ZTE)' }
 ];

--- a/frontend/src/components/NetworkDeviceCard.tsx
+++ b/frontend/src/components/NetworkDeviceCard.tsx
@@ -32,6 +32,7 @@ const vendorConfig: Record<string, { label: string; color: string; bgClass: stri
   huawei: { label: '华为', color: 'text-red-400', bgClass: 'bg-red-500/10 border border-red-500/20', icon: '🔴' },
   cisco: { label: '思科', color: 'text-blue-400', bgClass: 'bg-blue-500/10 border border-blue-500/20', icon: '🔵' },
   h3c: { label: '华三', color: 'text-green-400', bgClass: 'bg-green-500/10 border border-green-500/20', icon: '' },
+  hikvision: { label: '海康', color: 'text-cyan-400', bgClass: 'bg-cyan-500/10 border border-cyan-500/20', icon: '' },
   ruijie: { label: '锐捷', color: 'text-purple-400', bgClass: 'bg-purple-500/10 border border-purple-500/20', icon: '🟣' },
   zte: { label: '中兴', color: 'text-orange-400', bgClass: 'bg-orange-500/10 border border-orange-500/20', icon: '' }
 };

--- a/frontend/src/components/WebTerminal.tsx
+++ b/frontend/src/components/WebTerminal.tsx
@@ -74,9 +74,10 @@ export default function WebTerminal({ serverId, serverName, token, onClose }: Te
     term.open(terminalRef.current);
     fitAddon.fit();
 
-    const socket = io(undefined, {
+    const socket = io(window.location.origin, {
+      path: '/socket.io/',
       auth: { token },
-      transports: ['websocket']
+      transports: ['websocket', 'polling']
     });
     socketRef.current = socket;
 

--- a/frontend/src/pages/NetworkDevices.tsx
+++ b/frontend/src/pages/NetworkDevices.tsx
@@ -199,12 +199,13 @@ export default function NetworkDevices() {
     return result;
   }, [devices, selectedVendor, searchQuery]);
 
-  const vendors = ['all', 'huawei', 'cisco', 'h3c', 'ruijie', 'zte'];
+  const vendors = ['all', 'huawei', 'cisco', 'h3c', 'hikvision', 'ruijie', 'zte'];
   const vendorLabels: Record<string, string> = {
     all: '全部厂商',
     huawei: '华为',
     cisco: '思科',
     h3c: '华三',
+    hikvision: '海康',
     ruijie: '锐捷',
     zte: '中兴'
   };


### PR DESCRIPTION
- Add Hikvision vendor with H3C-compatible commands in vendorAdapter
- Add Hikvision result parser mapping using H3C parsers
- Add Hikvision option to device modal, card, and filter UI
- Fix terminalService to support ssh_key_id credential lookup
- Fix WebTerminal socket.io connection path for proxy compatibility
- Add passphrase column to ssh_keys migration schema

## 变更类型

<!-- 请勾选以下适用的类型 -->

- [*] Bug 修复 (fix)
- [*] 新功能 (feat)


## 变更描述

- 网络设备添加海康（Hikvision）厂家支持，命令与华三兼容
修复web终端连接失败：
- 修复终端服务支持 ssh_key_id 凭证查询
- 修复 WebTerminal Socket.IO 连接路径
- 补充 passphrase 字段到数据库迁移 schema

## 相关问题

<!-- 关联的 Issue 编号，例如 Fixes #7 -->
 Fixes #7 

## 测试方法

<!-- 请描述如何测试这些变更 -->

- [*] 已在本地环境测试通过
- [* ] 已运行 `npm run lint` 检查代码风格
- [* ] 已运行后端测试 `cd backend && npm test`

## 截图（前端变更适用）
<img width="1815" height="647" alt="{53340E6F-0B9F-4677-BFCF-E6F2659D609B}" src="https://github.com/user-attachments/assets/1f6b3c7b-9467-4d77-8da2-ef2a4e039cd0" />

<!-- 如果涉及前端 UI 变更，请附上截图 -->

<!-- 其他需要说明的内容 -->
