### PR TITLE
修复 Zabbix 告警自动处理匹配与追踪问题，并修复 Docker 本地部署启动异常Dev 20260623

### DIFF
--- a/backend/src/routes/alertMappingRoutes.ts
+++ b/backend/src/routes/alertMappingRoutes.ts
@@ -4,6 +4,12 @@ import { randomUUID } from 'crypto';
 
 const router = Router();
 
+function normalizeNullableCondition(value: unknown): string | null {
+  if (typeof value !== 'string') return value == null ? null : String(value);
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
 router.get('/', (_req: Request, res: Response) => {
   try {
     const mappings = db.prepare(`
@@ -56,7 +62,14 @@ router.post('/', (req: Request, res: Response) => {
     db.prepare(`
       INSERT INTO alert_workflow_mappings (id, alert_source, alert_severity, alert_title_pattern, workflow_id, enabled)
       VALUES (?, ?, ?, ?, ?, ?)
-    `).run(id, alert_source || null, alert_severity || null, alert_title_pattern || null, workflow_id, enabled ? 1 : 0);
+    `).run(
+      id,
+      normalizeNullableCondition(alert_source),
+      normalizeNullableCondition(alert_severity),
+      normalizeNullableCondition(alert_title_pattern),
+      workflow_id,
+      enabled ? 1 : 0
+    );
     
     res.status(201).json({ success: true, data: { id, alert_source, alert_severity, alert_title_pattern, workflow_id, enabled } });
   } catch {
@@ -86,15 +99,15 @@ router.put('/:id', (req: Request, res: Response) => {
     
     if (alert_source !== undefined) {
       updates.push('alert_source = ?');
-      params.push(alert_source);
+      params.push(normalizeNullableCondition(alert_source));
     }
     if (alert_severity !== undefined) {
       updates.push('alert_severity = ?');
-      params.push(alert_severity);
+      params.push(normalizeNullableCondition(alert_severity));
     }
     if (alert_title_pattern !== undefined) {
       updates.push('alert_title_pattern = ?');
-      params.push(alert_title_pattern);
+      params.push(normalizeNullableCondition(alert_title_pattern));
     }
     if (workflow_id) {
       updates.push('workflow_id = ?');

--- a/backend/src/routes/alertRoutes.ts
+++ b/backend/src/routes/alertRoutes.ts
@@ -7,6 +7,7 @@ import { remediationService } from '../services/remediationService';
 import { rootCauseAnalysisService } from '../services/rootCauseAnalysisService';
 import { alertService } from '../services/alertService';
 import { alertAutoAnalyzer } from '../services/alertAutoAnalyzer';
+import { alertWorkflowMappingService } from '../services/alertWorkflowMappingService';
 import { emitToAlerts } from '../websocket/handler';
 import { logger } from '../utils/logger';
 import { requireRole } from '../middleware/auth';
@@ -87,6 +88,22 @@ router.get('/:id', (req: Request, res: Response) => {
   }
 });
 
+router.get('/:id/automation-logs', (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const logs = db.prepare(`
+      SELECT * FROM audit_logs
+      WHERE resource_type = 'alert_automation' AND resource_id = ?
+      ORDER BY created_at DESC
+      LIMIT 100
+    `).all(id);
+
+    res.json({ success: true, data: logs });
+  } catch {
+    res.status(500).json({ success: false, error: 'Failed to fetch alert automation logs' });
+  }
+});
+
 router.post('/', async (req: Request, res: Response) => {
     try {
       const { source, severity, title, content, metadata, related_task_id } = req.body;
@@ -158,6 +175,7 @@ router.post('/', async (req: Request, res: Response) => {
         id,
         source: source || 'unknown',
         severity: severity || 'medium',
+        rawSeverity: typeof metadata?.raw_severity === 'string' ? metadata.raw_severity : undefined,
         title,
         content: content || '',
         tags: metadata?.tags ? (Array.isArray(metadata.tags) ? metadata.tags : []): [],
@@ -278,6 +296,7 @@ interface AlertProcessingContext {
   id: string;
   source: string;
   severity: string;
+  rawSeverity?: string;
   title: string;
   content: string;
   tags: string[];
@@ -286,7 +305,7 @@ interface AlertProcessingContext {
 async function runAlertProcessingPipeline(ctx: AlertProcessingContext): Promise<void> {
   const io = getIOInstance();
   try {
-    const { id, source, severity, title, content, tags } = ctx;
+    const { id, source, severity, rawSeverity, title, content, tags } = ctx;
 
     emitToAlerts(io!, 'remediation:started', {
       alertId: id,
@@ -314,7 +333,18 @@ async function runAlertProcessingPipeline(ctx: AlertProcessingContext): Promise<
     alertService.processDatabaseAlert(id);
 
     // 匹配修复策略并执行
-    const alertForMatching = { id, source, severity, title, content, tags };
+    const alertForMatching = { id, source, severity, rawSeverity, title, content, tags };
+    const mappingTask = alertWorkflowMappingService.triggerFirstMatchingWorkflow(alertForMatching);
+    if (mappingTask) {
+      emitToAlerts(io!, 'remediation:result', {
+        alertId: id,
+        policyId: mappingTask.mappingId,
+        policyName: `告警映射: ${mappingTask.workflowName}`,
+        executionId: mappingTask.taskId,
+        status: 'task_created',
+        timestamp: new Date().toISOString()
+      });
+    }
     const policies = await remediationService.matchAlertToPolicies(alertForMatching);
     for (const policy of policies) {
       const result = await remediationService.triggerRemediation(policy, alertForMatching);
@@ -360,24 +390,35 @@ router.post('/:id/process', async (req: Request, res: Response) => {
 
     // 解析 tags
     let tags: string[] = [];
+    let rawSeverity: string | undefined;
     if (alert.metadata) {
       try {
         const meta = typeof alert.metadata === 'string' ? JSON.parse(alert.metadata as string) : alert.metadata;
         tags = Array.isArray(meta.tags) ? meta.tags : [];
+        rawSeverity = typeof meta.raw_severity === 'string'
+          ? meta.raw_severity
+          : typeof meta.zabbix_raw_severity === 'string'
+            ? meta.zabbix_raw_severity
+            : undefined;
       } catch { /* ignore */ }
     }
 
-    const ctx: AlertProcessingContext = { id, source, severity, title, content, tags };
+    const ctx: AlertProcessingContext = { id, source, severity, rawSeverity, title, content, tags };
 
     // 同步匹配：确认有哪些修复策略匹配了
     let matchedPolicies: Array<{ id: string; name: string; execution_mode: string }> = [];
     let executionIds: string[] = [];
+    let mappingTasks: Array<{ taskId: string; mappingId: string; workflowId: string; workflowName: string }> = [];
     let errorMsg: string | null = null;
 
     try {
       // 先跑 alertService 的数据库处理
       alertService.processDatabaseAlert(id);
 
+      const mappingTask = alertWorkflowMappingService.triggerFirstMatchingWorkflow(ctx);
+      if (mappingTask) {
+        mappingTasks = [mappingTask];
+      }
       const policies = await remediationService.matchAlertToPolicies(ctx);
       matchedPolicies = policies.map(p => ({
         id: p.id,
@@ -426,10 +467,11 @@ router.post('/:id/process', async (req: Request, res: Response) => {
       success: true,
       message: errorMsg
         ? `告警处理完成，但部分策略执行出错: ${errorMsg}`
-        : `成功匹配 ${matchedPolicies.length} 条修复策略${executionIds.length ? '，执行已触发' : ''}`,
+        : `告警处理完成：匹配 ${matchedPolicies.length} 条修复策略，触发 ${mappingTasks.length} 个告警映射任务，创建 ${executionIds.length} 条修复执行记录`,
       data: {
         alertId: id,
         matchedPolicies,
+        mappingTasks,
         executionIds,
         error: errorMsg
       }

--- a/backend/src/routes/webhookRoutes.ts
+++ b/backend/src/routes/webhookRoutes.ts
@@ -19,6 +19,7 @@ import {
 } from '../services/alertSourceAdapters';
 import { alertDeviceResolver } from '../services/alertDeviceResolver';
 import { alertAutoAnalyzer } from '../services/alertAutoAnalyzer';
+import { alertWorkflowMappingService } from '../services/alertWorkflowMappingService';
 import { emitToAlerts } from '../websocket/handler';
 import { validateBody } from '../middleware/validation';
 import { z } from 'zod';
@@ -119,66 +120,6 @@ function verifyWebhookSignature(req: Request, source: string): boolean {
   );
 }
 
-function findAndTriggerWorkflow(alertId: string, source: string, severity: string, title: string): string | null {
-  try {
-    const mappings = db.prepare(`
-      SELECT * FROM alert_workflow_mappings
-      WHERE enabled = 1
-      AND (alert_source = ? OR alert_source IS NULL)
-      AND (alert_severity = ? OR alert_severity IS NULL)
-    `).all(source, severity);
-
-    const matchingMappings = (mappings as Array<{ alert_title_pattern?: string; workflow_id: string }>).filter(mapping => {
-      if (!mapping.alert_title_pattern) return true;
-      try {
-        return title.includes(mapping.alert_title_pattern);
-      } catch {
-        return false;
-      }
-    });
-
-    if (matchingMappings.length > 0) {
-      const mapping = matchingMappings[0];
-      const taskId = randomUUID();
-      const now = new Date().toISOString();
-
-      db.prepare(`
-        INSERT INTO tasks (id, workflow_id, name, status, created_at, initial_input, related_alert_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-      `).run(
-        taskId,
-        mapping.workflow_id,
-        `自动处理告警: ${title.substring(0, 50)}`,
-        'pending',
-        now,
-        JSON.stringify({ alertId, source, severity, title }),
-        alertId
-      );
-
-      db.prepare('UPDATE alerts SET related_task_id = ? WHERE id = ?').run(taskId, alertId);
-
-      createAuditLog({
-        action: 'auto_trigger_workflow',
-        resource_type: 'task',
-        resource_id: taskId,
-        details: { alertId, workflowId: mapping.workflow_id },
-      });
-
-      const io = getIOInstance();
-      if (io) {
-        io.emit('task:created', { id: taskId, name: `自动处理告警: ${title}`, workflowId: mapping.workflow_id });
-      }
-
-      return taskId;
-    }
-
-    return null;
-  } catch (error) {
-    logger.error('Error triggering workflow:', error);
-    return null;
-  }
-}
-
 function processNormalizedAlert(
   alert: NormalizedAlert,
   sourceLabel: string
@@ -247,6 +188,7 @@ function processNormalizedAlert(
         id,
         source: alert.source,
         severity,
+        rawSeverity: alert.raw_severity,
         title,
         content: alert.content,
         tags: [] as string[],
@@ -284,6 +226,17 @@ function processNormalizedAlert(
       }
 
       // ── 修复策略执行 ──
+      const mappingTask = alertWorkflowMappingService.triggerFirstMatchingWorkflow(alertForMatching);
+      if (mappingTask && io) {
+        emitToAlerts(io, 'remediation:result', {
+          alertId: id,
+          policyId: mappingTask.mappingId,
+          policyName: `告警映射: ${mappingTask.workflowName}`,
+          executionId: mappingTask.taskId,
+          status: 'task_created',
+          timestamp: new Date().toISOString()
+        });
+      }
       const matchedPolicies = await remediationService.matchAlertToPolicies(alertForMatching);
       for (const policy of matchedPolicies) {
         logger.info(`🔧 [Webhook] 匹配到修复策略: ${policy.name}, 自动触发...`);
@@ -337,7 +290,7 @@ function processNormalizedAlert(
     action: 'alert_received',
     resource_type: 'alert',
     resource_id: id,
-    details: { source: alert.source, severity, title, executionIds },
+    details: { source: alert.source, severity, rawSeverity: alert.raw_severity, title, executionIds },
   });
 
   if (io) {

--- a/backend/src/services/alertSourceAdapters.ts
+++ b/backend/src/services/alertSourceAdapters.ts
@@ -1,9 +1,11 @@
 import { logger } from '../utils/logger';
+import { normalizeSeverityLabel } from '../utils/alertSeverity';
 
 export interface NormalizedAlert {
   external_id?: string;
   source: string;
   severity: string;
+  raw_severity?: string;
   title: string;
   content: string;
   metadata: Record<string, unknown>;
@@ -18,31 +20,6 @@ export interface NormalizedAlert {
 export interface AlertAdapterResult {
   alerts: NormalizedAlert[];
   errors: string[];
-}
-
-function normalizeSeverity(level: string | number): string {
-  if (typeof level === 'number') {
-    if (level >= 5) return 'critical';
-    if (level >= 4) return 'high';
-    if (level >= 3) return 'medium';
-    if (level >= 2) return 'low';
-    return 'info';
-  }
-  const map: Record<string, string> = {
-    critical: 'critical',
-    critical_severity: 'critical',
-    disaster: 'critical',
-    high: 'high',
-    error: 'high',
-    warning: 'medium',
-    warn: 'medium',
-    average: 'medium',
-    information: 'low',
-    info: 'low',
-    low: 'low',
-    not_classified: 'info',
-  };
-  return map[level.toLowerCase()] || 'medium';
 }
 
 export function adaptPrometheus(payload: unknown): AlertAdapterResult {
@@ -67,7 +44,8 @@ export function adaptPrometheus(payload: unknown): AlertAdapterResult {
       alerts.push({
         external_id: `${labels.alertname || 'unknown'}-${labels.instance || ''}-${status}`,
         source: 'prometheus',
-        severity: normalizeSeverity(labels.severity || 'medium'),
+        severity: normalizeSeverityLabel(labels.severity || 'medium'),
+        raw_severity: labels.severity || 'medium',
         title: annotations.summary || labels.alertname || 'Prometheus Alert',
         content: annotations.description || annotations.message || JSON.stringify(alert),
         metadata: {
@@ -121,7 +99,7 @@ export function adaptZabbix(payload: unknown): AlertAdapterResult {
     const host = (hostObj?.NAME as string) || (body.host as string) || ((eventObj?.host as Record<string, unknown>)?.name as string) || 'Unknown';
     const hostIp = (hostObj?.IP as string) || (body.host_ip as string) || '';
     const rawSeverity = (triggerObj?.SEVERITY as string) || (triggerObj?.PRIORITY as string | number) || (body.severity as string | number) || ((eventObj?.severity as string));
-    const severity = normalizeSeverity(rawSeverity);
+    const severity = normalizeSeverityLabel(rawSeverity);
     const eventId = (body.EVENT as Record<string, unknown>)?.ID || (eventObj?.id as string) || (body.eventid as string);
     const triggerId = (triggerObj?.ID as string) || (body.triggerid as string);
     const item = (itemObj?.NAME as string) || (body.item as string) || '';
@@ -145,9 +123,11 @@ export function adaptZabbix(payload: unknown): AlertAdapterResult {
       external_id: eventId ? `zabbix-${eventId}` : undefined,
       source: 'zabbix',
       severity,
+      raw_severity: rawSeverity == null ? undefined : String(rawSeverity),
       title: `[${severity.toUpperCase()}] ${trigger}`,
       content,
       metadata: {
+        raw_severity: rawSeverity == null ? null : String(rawSeverity),
         zabbix_host: host,
         zabbix_host_ip: hostIp,
         zabbix_trigger_id: triggerId,
@@ -194,7 +174,8 @@ export function adaptGrafana(payload: unknown): AlertAdapterResult {
       alerts.push({
         external_id: alert.ruleUID ? `grafana-${alert.ruleUID}` : undefined,
         source: 'grafana',
-        severity: normalizeSeverity(rawSeverity),
+        severity: normalizeSeverityLabel(rawSeverity),
+        raw_severity: rawSeverity == null ? undefined : String(rawSeverity),
         title,
         content,
         metadata: {
@@ -256,7 +237,8 @@ export function adaptAliyun(payload: unknown): AlertAdapterResult {
     alerts.push({
       external_id: body.alertId || body.ruleId ? `aliyun-${body.alertId || body.ruleId}` : undefined,
       source: 'aliyun',
-      severity: normalizeSeverity(level),
+      severity: normalizeSeverityLabel(level),
+      raw_severity: level == null ? undefined : String(level),
       title: `[${product}] ${name}`,
       content: contentParts,
       metadata: {
@@ -311,7 +293,8 @@ export function adaptTencentCloud(payload: unknown): AlertAdapterResult {
     alerts.push({
       external_id: policyId ? `tencent-${policyId}` : undefined,
       source: 'tencent',
-      severity: normalizeSeverity(level),
+      severity: normalizeSeverityLabel(level),
+      raw_severity: level == null ? undefined : String(level),
       title: `[${alarmType}] ${alarmName}`,
       content: contentParts,
       metadata: {

--- a/backend/src/services/remediationService.ts
+++ b/backend/src/services/remediationService.ts
@@ -241,8 +241,8 @@ class RemediationService {
 
   private severityMatches(policySeverity: string | null, alertSeverity: string | undefined): boolean {
     if (!policySeverity) return true;
-    const pr = this.severityRank.get(policySeverity) ?? 0;
-    const ar = this.severityRank.get(alertSeverity ?? '') ?? 0;
+    const pr = this.severityRank.get(policySeverity.toLowerCase()) ?? 0;
+    const ar = this.severityRank.get((alertSeverity ?? '').toLowerCase()) ?? 0;
     // 策略要求 severity >= X，告警的 severity 也要 >= X
     // 例: policy=warning(2) 匹配 alert=high(3) 或 warning(2) 或 medium(2)
     //     policy=high(3) 只匹配 alert=critical(4)/high(3)
@@ -251,19 +251,26 @@ class RemediationService {
   }
 
   async matchAlertToPolicies(alert: { id: string; source: string; severity?: string; title?: string; content?: string; tags?: string[] }): Promise<RemediationPolicy[]> {
+    const normalizedAlert = {
+      ...alert,
+      source: (alert.source || 'unknown').toLowerCase(),
+      severity: alert.severity?.toLowerCase(),
+      tags: (alert.tags || []).map(tag => tag.toLowerCase())
+    };
+
     // 1. 先精确匹配 source（zabbix/prometheus/...）
-    const specificPolicies = this._matchBySource(alert);
+    const specificPolicies = this._matchBySource(normalizedAlert);
     if (specificPolicies.length > 0) return specificPolicies;
 
     // 2. 没有匹配 → 降级到 source=null 的通用策略
-    const fallbackPolicies = this._matchBySource({ ...alert, source: '__any__' });
+    const fallbackPolicies = this._matchBySource({ ...normalizedAlert, source: '__any__' });
     return fallbackPolicies;
   }
 
   private _matchBySource(alert: { id: string; source: string; severity?: string; title?: string; content?: string; tags?: string[] }): RemediationPolicy[] {
     const policies = db.prepare(`
       SELECT * FROM remediation_policies
-      WHERE enabled = 1 AND (alert_source = ? OR alert_source = '*')
+      WHERE enabled = 1 AND (LOWER(alert_source) = ? OR alert_source = '*')
       ORDER BY
         CASE
           WHEN alert_source = ? THEN 0 ELSE 1
@@ -281,9 +288,10 @@ class RemediationService {
 
     return policies.filter(policy => {
       // 通配符匹配：策略的 alert_source 为 '*' 时匹配任意告警 source
-      if (!policy.alert_source || policy.alert_source === '*') {
+      const policySource = policy.alert_source?.toLowerCase();
+      if (!policySource || policySource === '*') {
         // 通配符，不按 source 过滤
-      } else if (policy.alert_source !== alert.source) {
+      } else if (policySource !== alert.source) {
         return false;
       }
 
@@ -293,6 +301,9 @@ class RemediationService {
       }
 
       // 关键词匹配
+      let keywordMatched = !policy.alert_keywords;
+      let tagMatched = !policy.alert_tags;
+
       if (policy.alert_keywords) {
         try {
           const keywords = JSON.parse(policy.alert_keywords) as string[];
@@ -301,9 +312,7 @@ class RemediationService {
             return true;
           }
           const alertText = `${alert.title || ''} ${alert.content || ''}`.toLowerCase();
-          if (!keywords.some(kw => alertText.includes(kw.toLowerCase()))) {
-            return false;
-          }
+          keywordMatched = keywords.some(kw => alertText.includes(kw.toLowerCase()));
         } catch {
           logger.warn(`Invalid alert_keywords JSON in policy ${policy.id}`);
           return false;
@@ -318,16 +327,14 @@ class RemediationService {
             return true;
           }
           const alertTags = alert.tags || [];
-          if (!tags.some(t => alertTags.includes(t))) {
-            return false;
-          }
+          tagMatched = tags.some(t => alertTags.includes(t.toLowerCase()));
         } catch {
           logger.warn(`Invalid alert_tags JSON in policy ${policy.id}`);
           return false;
         }
       }
 
-      return true;
+      return keywordMatched || tagMatched;
     });
   }
 

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -82,7 +82,7 @@ COPY backend/package.json ./
 
 # Copy entrypoint script
 COPY docker/docker-entrypoint-backend.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Create data directory for SQLite database
 RUN mkdir -p /app/data

--- a/frontend/src/pages/AlertMappings.tsx
+++ b/frontend/src/pages/AlertMappings.tsx
@@ -380,10 +380,13 @@ export default function AlertMappings() {
                   className="w-full px-3 py-2.5 bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
                 >
                   <option value="">✨ 任意级别</option>
+                  <option value="disaster">💥 Disaster (Zabbix 灾难)</option>
                   <option value="critical">🔴 Critical (严重)</option>
                   <option value="high">🟠 High (高)</option>
                   <option value="medium">🟡 Medium (中)</option>
+                  <option value="warning">🟨 Warning (Zabbix 警告)</option>
                   <option value="low">🔵 Low (低)</option>
+                  <option value="info">ℹ️ Info (信息)</option>
                 </select>
               </div>
 
@@ -441,7 +444,7 @@ export default function AlertMappings() {
                   </div>
                   <div className="text-sm text-blue-800">
                     <p className="font-medium mb-1">配置说明</p>
-                    <p>留空的条件表示匹配任意值，多个条件需要同时满足才会触发工作流。</p>
+                    <p>留空的条件表示匹配任意值。Zabbix 可直接使用 disaster、warning、info 等原始级别，也可使用 critical、medium、low 等归一化级别。</p>
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -20,14 +20,23 @@ interface Alert {
   content: string;
   status: string;
   metadata: Record<string, unknown>;
+  related_task_id?: string | null;
   created_at: string;
 }
 
 interface ProcessResult {
   alertId: string;
   matchedPolicies: Array<{ id: string; name: string; execution_mode: string }>;
+  mappingTasks?: Array<{ taskId: string; mappingId: string; workflowId: string; workflowName: string }>;
   executionIds: string[];
   error: string | null;
+}
+
+interface AutomationLog {
+  id: string;
+  action: string;
+  details: string | null;
+  created_at: string;
 }
 
 export default function Alerts() {
@@ -36,6 +45,7 @@ export default function Alerts() {
   const [searchQuery, setSearchQuery] = useState('');
   const [severityFilter, setSeverityFilter] = useState<string>('all');
   const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [automationLogAlert, setAutomationLogAlert] = useState<Alert | null>(null);
   const [wsConnected, setWsConnected] = useState(false);
   const socketRef = useRef<Socket | null>(null);
   const reconnectAttemptRef = useRef(0);
@@ -64,6 +74,15 @@ export default function Alerts() {
       return map;
     },
     refetchInterval: 30000,
+  });
+
+  const { data: automationLogs = [], isLoading: automationLogsLoading } = useQuery({
+    queryKey: ['alert-automation-logs', automationLogAlert?.id],
+    enabled: !!automationLogAlert,
+    queryFn: async () => {
+      const res = await api.get(`/api/alerts/${automationLogAlert!.id}/automation-logs`);
+      return (res.data.data || []) as AutomationLog[];
+    },
   });
 
   const connectWebSocketRef = useRef<ReturnType<typeof connectWebSocketInner> | null>(null);
@@ -217,6 +236,18 @@ export default function Alerts() {
       refetch();
     },
   });
+
+  const hasProcessRecords = (result: ProcessResult) =>
+    result.matchedPolicies.length > 0 || (result.mappingTasks?.length || 0) > 0;
+
+  const formatAutomationLogDetails = (details: string | null) => {
+    if (!details) return '无详情';
+    try {
+      return JSON.stringify(JSON.parse(details), null, 2);
+    } catch {
+      return details;
+    }
+  };
 
   return (
     <div className="h-full overflow-auto p-6">
@@ -402,6 +433,22 @@ export default function Alerts() {
                     修复记录
                   </button>
                   <button
+                    onClick={() => setAutomationLogAlert(alert)}
+                    className="flex items-center gap-1 text-xs text-slate-300 hover:text-white transition-colors px-2 py-1 rounded bg-slate-500/10 hover:bg-slate-500/20"
+                  >
+                    <Clock className="w-3 h-3" />
+                    自动处理记录
+                  </button>
+                  {alert.related_task_id && (
+                    <button
+                      onClick={() => navigate(`/tasks?taskId=${encodeURIComponent(alert.related_task_id!)}`)}
+                      className="flex items-center gap-1 text-xs text-cyan-400 hover:text-cyan-300 transition-colors px-2 py-1 rounded bg-cyan-500/5 hover:bg-cyan-500/10"
+                    >
+                      <Terminal className="w-3 h-3" />
+                      工作流任务
+                    </button>
+                  )}
+                  <button
                     onClick={() => navigate(`/inspection-center?alertId=${alert.id}`)}
                     className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors px-2 py-1 rounded bg-blue-500/5 hover:bg-blue-500/10"
                   >
@@ -436,14 +483,14 @@ export default function Alerts() {
             <div className={`p-4 border-b border-border flex items-center justify-between rounded-t-xl ${
               processResult.error
                 ? 'bg-gradient-to-r from-amber-500/10 to-red-500/10'
-                : processResult.matchedPolicies.length > 0
+                : hasProcessRecords(processResult)
                   ? 'bg-gradient-to-r from-green-500/10 to-blue-500/10'
                   : 'bg-gradient-to-r from-blue-500/10 to-purple-500/10'
             }`}>
               <h3 className="text-lg font-semibold text-text-primary flex items-center gap-2">
                 {processResult.error ? (
                   <AlertCircle2 className="w-5 h-5 text-red-500" />
-                ) : processResult.matchedPolicies.length > 0 ? (
+                ) : hasProcessRecords(processResult) ? (
                   <CheckCircle2 className="w-5 h-5 text-green-500" />
                 ) : (
                   <Play className="w-5 h-5 text-blue-500" />
@@ -463,15 +510,15 @@ export default function Alerts() {
               <div className={`p-3 rounded-lg border ${
                 processResult.error
                   ? 'bg-red-500/10 border-red-500/20 text-red-600 dark:text-red-400'
-                  : processResult.matchedPolicies.length > 0
+                  : hasProcessRecords(processResult)
                     ? 'bg-green-500/10 border-green-500/20 text-green-600 dark:text-green-400'
                     : 'bg-blue-500/10 border-blue-500/20 text-blue-600 dark:text-blue-400'
               }`}>
                 <p className="text-sm font-medium">
                   {processResult.error
                     ? '⚠️ 执行遇到错误: ' + processResult.error
-                    : processResult.matchedPolicies.length > 0
-                      ? `✅ 成功匹配 ${processResult.matchedPolicies.length} 条修复策略，${processResult.executionIds.length} 个执行已触发`
+                    : hasProcessRecords(processResult)
+                      ? `触发 ${processResult.matchedPolicies.length} 条修复策略，${processResult.mappingTasks?.length || 0} 个告警映射任务，${processResult.executionIds.length} 条修复执行记录已创建`
                       : 'ℹ️ 未匹配到任何修复策略（告警级别/关键词不满足已有策略条件）'}
                 </p>
               </div>
@@ -506,6 +553,23 @@ export default function Alerts() {
               )}
 
               {/* 执行ID */}
+              {!!processResult.mappingTasks?.length && (
+                <div>
+                  <h4 className="text-sm font-semibold text-text-primary mb-2 flex items-center gap-1.5">
+                    <Terminal className="w-4 h-4 text-primary" />
+                    告警映射工作流任务
+                  </h4>
+                  <div className="space-y-2">
+                    {processResult.mappingTasks.map((task) => (
+                      <div key={task.taskId} className="p-2.5 bg-background rounded-lg border border-border">
+                        <div className="text-sm text-text-primary">{task.workflowName}</div>
+                        <code className="block text-xs text-text-secondary truncate mt-1">{task.taskId}</code>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {processResult.executionIds.length > 0 && (
                 <div>
                   <h4 className="text-sm font-semibold text-text-primary mb-2">执行记录 ID</h4>
@@ -540,6 +604,19 @@ export default function Alerts() {
                   查看执行记录
                 </button>
               )}
+              {!!processResult.mappingTasks?.length && (
+                <button
+                  onClick={() => {
+                    setProcessResult(null);
+                    const taskId = processResult.mappingTasks?.[0]?.taskId;
+                    navigate(taskId ? `/tasks?taskId=${encodeURIComponent(taskId)}` : '/tasks');
+                  }}
+                  className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors font-medium text-sm flex items-center gap-1.5"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                  查看工作流任务
+                </button>
+              )}
             </div>
           </div>
         </div>
@@ -551,6 +628,50 @@ export default function Alerts() {
           <div className="bg-surface rounded-xl border border-border p-6 shadow-2xl flex items-center gap-3">
             <Loader2 className="w-5 h-5 animate-spin text-primary" />
             <span className="text-text-primary font-medium">正在处理告警...</span>
+          </div>
+        </div>
+      )}
+
+      {automationLogAlert && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+          <div className="bg-surface rounded-xl border border-border max-w-3xl w-full shadow-2xl max-h-[80vh] flex flex-col">
+            <div className="p-4 border-b border-border flex items-center justify-between rounded-t-xl">
+              <div>
+                <h3 className="text-lg font-semibold text-text-primary">自动处理记录</h3>
+                <p className="text-sm text-text-secondary mt-1">{sanitizeText(automationLogAlert.title)}</p>
+              </div>
+              <button
+                onClick={() => setAutomationLogAlert(null)}
+                className="p-1.5 rounded-lg hover:bg-background transition-colors"
+              >
+                <XIcon className="w-4 h-4" />
+              </button>
+            </div>
+
+            <div className="p-5 overflow-auto flex-1">
+              {automationLogsLoading ? (
+                <div className="flex items-center gap-3 text-text-secondary">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span>加载处理中...</span>
+                </div>
+              ) : automationLogs.length === 0 ? (
+                <div className="text-sm text-text-secondary">暂无自动处理记录</div>
+              ) : (
+                <div className="space-y-3">
+                  {automationLogs.map((log) => (
+                    <div key={log.id} className="border border-border rounded-lg p-3 bg-background">
+                      <div className="flex items-center justify-between gap-3 mb-2">
+                        <span className="text-sm font-medium text-text-primary">{log.action}</span>
+                        <span className="text-xs text-text-secondary">{new Date(log.created_at).toLocaleString()}</span>
+                      </div>
+                      <pre className="text-xs text-text-secondary whitespace-pre-wrap break-all">
+                        {formatAutomationLogDetails(log.details)}
+                      </pre>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router-dom';
 import { io, Socket } from 'socket.io-client';
 import { Play, Pause, XCircle, Clock, CheckCircle, XCircle as XIcon, FileText, Activity, List, FileCheck } from 'lucide-react';
 import { formatDistanceToNow, format } from 'date-fns';
@@ -33,6 +34,8 @@ interface Workflow {
 
 export default function Tasks() {
   const { token } = useAuth();
+  const [searchParams] = useSearchParams();
+  const taskIdFromQuery = searchParams.get('taskId');
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [executingNodeId, setExecutingNodeId] = useState<string | null>(null);
   const [taskLogs, setTaskLogs] = useState<any[]>([]);
@@ -311,6 +314,15 @@ export default function Tasks() {
     setSelectedTask(parsedTask);
     setTaskLogs(parsedLogs);
   };
+
+  useEffect(() => {
+    if (!taskIdFromQuery || !tasks || selectedTask?.id === taskIdFromQuery) return;
+
+    const task = tasks.find((item) => item.id === taskIdFromQuery);
+    if (task) {
+      handleSelectTask(task);
+    }
+  }, [taskIdFromQuery, selectedTask?.id, tasks]);
 
   const pauseMutation = useMutation({
     mutationFn: async (taskId: string) => {


### PR DESCRIPTION
当前告警自动处理有两个明显问题：

Zabbix 上送的告警虽然进入系统，但经常匹配不到自动处理规则。
自动处理触发后缺少可追踪的详细记录，排查时只能看到结果，看不到匹配过程和失败原因。
另外，本地 Docker 部署时，后端容器存在入口脚本执行失败的问题，导致服务无法正常启动。

本次改动
1. 修复 Zabbix 告警规则匹配
统一了告警级别匹配逻辑，兼容 Zabbix 原始级别和系统归一化级别。
兼容的级别包括：
原始级别：disaster、warning、info
归一化级别：critical、high、medium、low
修复了空条件和通配条件处理不一致的问题：
NULL
空字符串 ''
通配来源 *
修复编辑映射规则后，空条件被保存为空字符串导致匹配失效的问题。
2. 增加自动处理过程记录
为告警自动处理新增审计日志记录，记录内容包括：
告警来源
原始严重级别 / 归一化严重级别
候选映射规则
是否命中
未命中的原因
最终选中的工作流
新增告警自动处理日志查询接口：
GET /api/alerts/:id/automation-logs
前端告警页新增“自动处理记录”入口，可直接查看处理过程明细。
3. 优化自动映射后的任务可见性
告警触发映射工作流后，会创建 tasks 记录并关联到告警。
告警页增加“工作流任务”入口。
任务页支持通过 taskId 自动定位到对应任务，便于快速排查执行情况。
4. 修复 Docker 本地运行问题
修复后端镜像入口脚本因 CRLF 换行导致的容器启动失败问题。
在镜像构建时统一转换为 Unix 换行，保证 Linux 容器可正常执行。
验证
已完成以下验证：

backend 构建通过
frontend 构建通过
Docker 镜像构建通过
本地 docker compose 启动通过
后端健康检查通过：/health
前端页面可正常访问
影响范围
告警自动处理规则匹配
Zabbix webhook 告警处理链路
告警审计与问题排查体验
本地 / Linux Docker 部署启动流程
风险说明
本次主要是匹配逻辑修正和可观测性增强，未改动数据库表结构。
映射规则命中结果可能相比之前更符合预期，部分历史“未命中”告警在修复后会开始正常触发工作流。