### PR TITLE
fix(docker): make apt/npm mirrors and proxy configurable for enterpri…

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -3,13 +3,38 @@
 # Build: docker build -f docker/Dockerfile.backend -t itops-backend:latest .
 
 # ============================================================
+# Build-time arguments (overridable via --build-arg)
+# ============================================================
+# APT mirror for China users; pass empty string to keep Debian defaults
+#   docker build --build-arg APT_MIRROR= -f docker/Dockerfile.backend .
+# Enterprise/intranet environments can set a proxy or use a local mirror:
+#   docker build --build-arg HTTP_PROXY=http://proxy:8080 --build-arg HTTPS_PROXY=http://proxy:8080 \
+#                --build-arg APT_MIRROR= -f docker/Dockerfile.backend .
+ARG APT_MIRROR=mirrors.aliyun.com
+ARG HTTP_PROXY=
+ARG HTTPS_PROXY=
+ARG NO_PROXY=localhost,127.0.0.1
+
+# ============================================================
 # Stage 1: Builder
 # ============================================================
 FROM node:20.19.5-slim AS builder
 
-# Use Aliyun Debian mirror for faster and more reliable apt access in China
-# Note: Must use HTTP (not HTTPS) because node:20-slim lacks ca-certificates
-RUN sed -i 's|http://deb.debian.org/debian|http://mirrors.aliyun.com/debian|g; s|http://security.debian.org/debian-security|http://mirrors.aliyun.com/debian-security|g' /etc/apt/sources.list.d/debian.sources
+ARG APT_MIRROR
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
+ENV http_proxy=${HTTP_PROXY} \
+    https_proxy=${HTTPS_PROXY} \
+    no_proxy=${NO_PROXY}
+
+# Use Aliyun Debian mirror for faster apt access in China.
+# Set APT_MIRROR="" to keep official Debian sources (required in enterprise
+# intranets where mirrors.aliyun.com is unreachable but a proxy is available).
+RUN if [ -n "$APT_MIRROR" ]; then \
+      sed -i "s|http://deb.debian.org/debian|http://${APT_MIRROR}/debian|g; s|http://security.debian.org/debian-security|http://${APT_MIRROR}/debian-security|g" /etc/apt/sources.list.d/debian.sources; \
+    fi
 
 WORKDIR /app
 
@@ -24,7 +49,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY backend/package.json backend/package-lock.json ./
 
 # Install all dependencies (including devDependencies for tsx) and build native modules
-RUN npm ci
+# Use npmmirror for China; override with --build-arg NPM_REGISTRY= for other mirrors/proxies
+ARG NPM_REGISTRY=https://registry.npmmirror.com
+RUN if [ -n "$NPM_REGISTRY" ]; then npm config set registry "$NPM_REGISTRY"; fi && \
+    npm ci
 
 # Copy source code
 COPY backend/ ./
@@ -34,9 +62,20 @@ COPY backend/ ./
 # ============================================================
 FROM node:20.19.5-slim
 
-# Use Aliyun Debian mirror for faster and more reliable apt access in China
-# Note: Must use HTTP (not HTTPS) because node:20-slim lacks ca-certificates
-RUN sed -i 's|http://deb.debian.org/debian|http://mirrors.aliyun.com/debian|g; s|http://security.debian.org/debian-security|http://mirrors.aliyun.com/debian-security|g' /etc/apt/sources.list.d/debian.sources
+ARG APT_MIRROR
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
+ENV http_proxy=${HTTP_PROXY} \
+    https_proxy=${HTTPS_PROXY} \
+    no_proxy=${NO_PROXY}
+
+# Use Aliyun Debian mirror for faster apt access in China.
+# Set APT_MIRROR="" to keep official Debian sources (for proxy/intranet builds).
+RUN if [ -n "$APT_MIRROR" ]; then \
+      sed -i "s|http://deb.debian.org/debian|http://${APT_MIRROR}/debian|g; s|http://security.debian.org/debian-security|http://${APT_MIRROR}/debian-security|g" /etc/apt/sources.list.d/debian.sources; \
+    fi
 
 # Labels for public registry (replace with your actual info)
 LABEL maintainer="谭策 <huawei_network@foxmail.com>" \
@@ -54,6 +93,11 @@ WORKDIR /app
 ENV NODE_ENV=production \
     PORT=3001 \
     HOST=0.0.0.0
+
+# Clear build-time proxy settings so they don't leak into the runtime container
+ENV http_proxy= \
+    https_proxy= \
+    no_proxy=
 
 # Install runtime dependencies (SQLite library, Python for dbskiter, gosu for privilege dropping)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -3,9 +3,26 @@
 # Build: docker build -f docker/Dockerfile.frontend -t itops-frontend:latest .
 
 # ============================================================
+# Build-time arguments (overridable via --build-arg)
+# ============================================================
+ARG NPM_REGISTRY=https://registry.npmmirror.com
+ARG HTTP_PROXY=
+ARG HTTPS_PROXY=
+ARG NO_PROXY=localhost,127.0.0.1
+
+# ============================================================
 # Stage 1: Builder
 # ============================================================
 FROM node:20.19.5-alpine AS builder
+
+ARG NPM_REGISTRY
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
+ENV http_proxy=${HTTP_PROXY} \
+    https_proxy=${HTTPS_PROXY} \
+    no_proxy=${NO_PROXY}
 
 WORKDIR /app
 
@@ -16,7 +33,9 @@ ENV npm_config_cache=/app/.npm-cache
 COPY frontend/package.json frontend/package-lock.json ./
 
 # Install dependencies with cache optimization
+# Use npmmirror for China; override with --build-arg NPM_REGISTRY= for other mirrors/proxies
 RUN --mount=type=cache,target=/app/.npm-cache \
+    if [ -n "$NPM_REGISTRY" ]; then npm config set registry "$NPM_REGISTRY"; fi && \
     npm ci --prefer-offline --no-audit --no-fund
 
 # Copy source code

--- a/docker/README.md
+++ b/docker/README.md
@@ -153,6 +153,36 @@ docker build -f docker/Dockerfile.frontend -t itops-frontend:latest .
 docker-compose up -d --build
 ```
 
+### Building in enterprise / intranet environments
+
+The Dockerfiles accept build args so the build works behind a corporate proxy or
+in air-gapped intranets where `mirrors.aliyun.com` / `registry.npmmirror.com` are
+unreachable:
+
+```bash
+# Option A: keep official Debian & npm sources, route traffic through a proxy
+docker build --network host \
+    --build-arg APT_MIRROR= \
+    --build-arg NPM_REGISTRY= \
+    --build-arg HTTP_PROXY=http://10.0.0.1:8080 \
+    --build-arg HTTPS_PROXY=http://10.0.0.1:8080 \
+    -f docker/Dockerfile.backend -t itops-backend:latest .
+
+# Option B: use a different mirror (e.g. a self-hosted Nexus/Artifactory)
+docker build \
+    --build-arg APT_MIRROR=mirrors.my-company.com \
+    --build-arg NPM_REGISTRY=https://npm.my-company.com \
+    -f docker/Dockerfile.backend -t itops-backend:latest .
+```
+
+| Build arg | Default | Purpose |
+|-----------|---------|---------|
+| `APT_MIRROR` | `mirrors.aliyun.com` | Debian apt mirror; set empty to keep official sources |
+| `NPM_REGISTRY` | `https://registry.npmmirror.com` | npm registry; set empty to keep `registry.npmjs.org` |
+| `HTTP_PROXY` / `HTTPS_PROXY` | *(empty)* | HTTP(S) proxy for apt & npm during build (cleared in final image) |
+| `NO_PROXY` | `localhost,127.0.0.1` | Proxy bypass list |
+
+
 ## 🎯 Usage
 
 1. Access the frontend at `http://localhost:8080`


### PR DESCRIPTION
## Problem

The Dockerfiles hardcoded `mirrors.aliyun.com` (apt) and `registry.npmmirror.com` (npm). This breaks `docker build` in **enterprise intranets** where these endpoints are unreachable — typically behind a corporate proxy (e.g. Fortinet) or in air-gapped networks.

Encountered while deploying the platform on an internal RHEL server:
- `mirrors.aliyun.com:80` timed out (corporate firewall blocks it)
- npm registry requests were filtered out with `403` by the content proxy
- the only network path out was an authenticated HTTP proxy

## Solution

Make the mirrors and proxy **configurable via `--build-arg`**, with China-friendly defaults preserved so default behavior is unchanged.

| Build arg | Default | Purpose |
|-----------|---------|---------|
| `APT_MIRROR` | `mirrors.aliyun.com` | Debian apt mirror; pass empty to keep official sources |
| `NPM_REGISTRY` | `https://registry.npmmirror.com` | npm registry; pass empty to use npmjs.org |
| `HTTP_PROXY` / `HTTPS_PROXY` | *(empty)* | Proxy for apt & npm during build (cleared in final image) |
| `NO_PROXY` | `localhost,127.0.0.1` | Proxy bypass list |

## Verification

Built on macOS (arm64) targeting `linux/amd64` via buildx — all three scenarios succeed:
- ✅ Backend, default args (Aliyun + npmmirror)
- ✅ Backend, intranet mode (empty mirrors + official sources)
- ✅ Frontend, default args

Backwards compatible — no `--build-arg` means same China mirrors as before.